### PR TITLE
Mudança da pagina de edição de zona

### DIFF
--- a/src/components/ButtonSaveModal/index.js
+++ b/src/components/ButtonSaveModal/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import LoadginGif from '../../assets/loading.gif';
+import { Button } from '../../styles/global';
+
+const ButtonSaveModal = (props) => (
+  <Tooltip
+    title={ props.title }
+    data-toggle={ props["data-toggle"] }
+    data-target={ props["data-target"] }
+    onClick={ props.onClick }
+    className={ props.className }
+    data-dismiss={ props["data-dismiss"] }
+    aria-label={ props["data-label"] }
+    type={ props.type }
+    disabled={ props.disabled }
+    style={{
+        ...props.style,
+      }}
+  >
+    <Button>
+        {
+        props.loading ?
+            (
+            <>
+                <img
+                src={ LoadginGif }
+                width="25"
+                style={{ marginRight: 10 }}
+                alt="Carregando"
+                />
+                Salvando...
+            </>
+            ) :
+            "Salvar"
+        }
+    </Button>
+  </Tooltip>
+);
+
+export default ButtonSaveModal;

--- a/src/pages/Zonas/EditarZona.js
+++ b/src/pages/Zonas/EditarZona.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 
 // ACTIONS
 import { changeSidebar } from '../../store/Sidebar/sidebarActions';
-import { updateZoneRequest, getZoneByIdRequest } from '../../store/Zona/zonaActions';
+import { updateZoneRequest, getZoneByIdRequest, clearUpdate } from '../../store/Zona/zonaActions';
 
 // STYLES
 import { FormGroup, selectDefault } from '../../styles/global';
@@ -43,7 +43,9 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
   useEffect( () => {
     setFlLoading( false );
     if( props.updateZone)
-      getZoneByIdRequest( id ); 
+      getZoneByIdRequest( id );
+    
+    props.clearUpdate();
   }, [ props.updateZone ] );
 
   function handleSubmit( e ) {
@@ -57,8 +59,6 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
         ativo: ativo.value,
         nome: nome
       });
-      
-      props.updateZone = true;
     }
   }
 
@@ -151,7 +151,8 @@ const mapDispatchToProps = dispatch =>
   bindActionCreators({
     changeSidebar,
     updateZoneRequest,
-    getZoneByIdRequest
+    getZoneByIdRequest,
+    clearUpdate
   }, dispatch);
 
 export default connect(

--- a/src/pages/Zonas/ModalAdd.js
+++ b/src/pages/Zonas/ModalAdd.js
@@ -1,7 +1,9 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Row, Col } from 'react-bootstrap';
 import Modal, { ModalBody, ModalFooter } from '../../components/Modal';
 import $ from 'jquery';
+import ButtonSaveModal from '../../components/ButtonSaveModal';
 
 // REDUX
 import { bindActionCreators } from 'redux';
@@ -12,12 +14,26 @@ import { createZoneRequest, clearCreate } from '../../store/Zona/zonaActions';
 
 // STYLES
 import { Button } from '../../styles/global';
+import { FormGroup } from '../../styles/global';
+
+// VALIDATIONS FUNCTIONS
+import {isBlank,onlyLetters} from '../../config/function';
 
 function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
+
+  const [ nome, setNome ]                 = useState( "" );
+  const [ isValidNome, setIsValidNome ]   = useState( true );
+  const [ flLoading, setFlLoading ]       = useState( false );
+
   function handleCadastrar( e ) {
     e.preventDefault();
-
-    createZoneRequest( municipio_id );
+    if(isBlank(nome))
+      setIsValidNome(false)
+    else{
+      setIsValidNome(true)
+      setFlLoading(true)
+      createZoneRequest( municipio_id, nome );
+    }
   }
 
   useEffect(() => {
@@ -25,21 +41,58 @@ function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
   }, []);
 
   useEffect(() => {
-    if( created ) {
-      $('#modal-novo-zona').modal('hide');
-      props.clearCreate();
+    setFlLoading(false)
+    if( created ){
+      closeModal();
     }
+    
+    props.clearCreate();
+    
   }, [ created ]);
+
+  function closeModal() {
+    clearInput();
+    $('#modal-novo-zona').modal('hide');
+  }
+
+  function clearInput() {
+    setIsValidNome(true);
+    setNome( "" );
+  }
 
   return(
     <Modal id="modal-novo-zona" title="Cadastrar Zona">
       <form onSubmit={ handleCadastrar }>
         <ModalBody>
-          <p>O nome da zona é gerado automaticamente, deseja realmente criar uma zona?</p>
+        <Row>
+            <Col>
+              <FormGroup>
+                <label htmlFor="nome">Nome <code>*</code></label>
+                <input 
+                  id="nome" 
+                  value={nome} 
+                  className ={ `form-control ${ !isValidNome ? 'invalid' : '' }` } 
+                  onChange={ (e) => (onlyLetters(e.target.value) ? setNome(e.target.value) : () => {} )} 
+                  required />
+                  {
+                    !isValidNome ?
+                      <span class="form-label-invalid">Nome inválido</span> :
+                      ''
+                  }
+              </FormGroup>
+            </Col>
+          </Row>
         </ModalBody>
         <ModalFooter>
-          <Button type="button" className="secondary" data-dismiss="modal">Cancelar</Button>
-          <Button type="submit">Salvar</Button>
+          <Button 
+            type="button" 
+            className="secondary" 
+            data-dismiss="modal" 
+            onClick = { closeModal } 
+            disabled={ flLoading }>
+              Cancelar
+          </Button>
+          <ButtonSaveModal title="Salvar" loading={ flLoading } disabled={ flLoading } type="submit" />
         </ModalFooter>
       </form>
     </Modal>

--- a/src/services/requests/Zona.js
+++ b/src/services/requests/Zona.js
@@ -14,10 +14,11 @@ export const getZoneByLocalityRequest = data => {
 }
 
 export const createZoneRequest = data => {
-  const { municipio_id } = data;
+  const { municipio_id, nome } = data;
 
   return api.post(`/zonas`, {
-    municipio_id
+    municipio_id,
+    nome
   },
   {
     ...headerAuthorization()

--- a/src/store/Zona/zonaActions.js
+++ b/src/store/Zona/zonaActions.js
@@ -9,6 +9,7 @@ export const ActionTypes = {
   CREATE_ZONE_SUCCESS: "CREATE_ZONE_SUCCESS",
   UPDATE_ZONE_REQUEST: "UPDATE_ZONE_REQUEST",
   UPDATE_ZONE_SUCCESS: "UPDATE_ZONE_SUCCESS",
+  UPDATE_ZONE_FAIL: "UPDATE_ZONE_FAIL",
   CLEAR_CREATE_ZONE: "CLEAR_CREATE_ZONE",
   CLEAR_UPDATE_ZONE: "CLEAR_UPDATE_ZONE"
 }
@@ -98,6 +99,12 @@ export const updateZone = zona => {
     payload: {
       zona
     }
+  }
+}
+
+export const updateZoneFail = () => {
+  return {
+    type: ActionTypes.UPDATE_ZONE_FAIL,
   }
 }
 

--- a/src/store/Zona/zonaActions.js
+++ b/src/store/Zona/zonaActions.js
@@ -7,6 +7,7 @@ export const ActionTypes = {
   GET_ZONE_BY_LOCALITY_SUCCESS: "GET_ZONE_BY_LOCALITY_SUCCESS",
   CREATE_ZONE_REQUEST: "CREATE_ZONE_REQUEST",
   CREATE_ZONE_SUCCESS: "CREATE_ZONE_SUCCESS",
+  CREATE_ZONE_FAIL: "CREATE_ZONE_FAIL",
   UPDATE_ZONE_REQUEST: "UPDATE_ZONE_REQUEST",
   UPDATE_ZONE_SUCCESS: "UPDATE_ZONE_SUCCESS",
   UPDATE_ZONE_FAIL: "UPDATE_ZONE_FAIL",
@@ -68,11 +69,12 @@ export const getZoneByLocality = zonas => {
   }
 }
 
-export const createZoneRequest = ( municipio_id ) => {
+export const createZoneRequest = ( municipio_id, nome ) => {
   return {
     type: ActionTypes.CREATE_ZONE_REQUEST,
     payload: {
-      municipio_id
+      municipio_id,
+      nome
     }
   }
 }
@@ -83,6 +85,12 @@ export const createZone = zona => {
     payload: {
       zona
     }
+  }
+}
+
+export const createZoneFail = () => {
+  return {
+    type: ActionTypes.CREATE_ZONE_FAIL,
   }
 }
 

--- a/src/store/Zona/zonaReduce.js
+++ b/src/store/Zona/zonaReduce.js
@@ -53,7 +53,6 @@ export default function Zona(state = INITIAL_STATE, action) {
       }
     }
 
-
     case ActionTypes.UPDATE_ZONE_SUCCESS: {
       let zonas = state.zonas;
       const zona = action.payload.zona;
@@ -67,6 +66,13 @@ export default function Zona(state = INITIAL_STATE, action) {
         zonas,
         updated: true,
         reload: !state.reload
+      }
+    }
+
+    case ActionTypes.UPDATE_ZONE_FAIL: {
+      return {
+        ...state,
+        updated: false
       }
     }
 

--- a/src/store/Zona/zonaReduce.js
+++ b/src/store/Zona/zonaReduce.js
@@ -46,6 +46,13 @@ export default function Zona(state = INITIAL_STATE, action) {
       }
     }
 
+    case ActionTypes.CREATE_ZONE_FAIL: {
+      return {
+        ...state,
+        created: false
+      }
+    }
+
     case ActionTypes.CLEAR_CREATE_ZONE: {
       return {
         ...state,

--- a/src/store/Zona/zonaSagas.js
+++ b/src/store/Zona/zonaSagas.js
@@ -51,15 +51,21 @@ export function* createZone( action ) {
 export function* updateZone( action ) {
   try {
     const { data, status } = yield call( servico.updateRequest, action.payload );
-
     if( status === 200 ) {
       yield put( ZonaActions.updateZone( data ) );
       yield put( AppConfigActions.showNotifyToast( "Zona atualizada com sucesso", "success" ) );
     } else {
       yield put( AppConfigActions.showNotifyToast( "Falha ao atualizar as informações da zona: " + status, "error" ) );
     }
-  } catch (error) {
-    yield put( AppConfigActions.showNotifyToast( "Erro ao atualizar a zona, favor verifique sua conexão com a internet", "error" ) );
+  } catch (err) {
+    const {alreadyExist, error} = err.response.data
+
+    yield put( ZonaActions.updateZoneFail() )
+    
+    if(alreadyExist)
+      yield put( AppConfigActions.showNotifyToast( error, "error" ) );
+    else
+     yield put( AppConfigActions.showNotifyToast( "Erro ao atualizar a zona, favor verifique sua conexão com a internet", "error" ) );
   }
 }
 

--- a/src/store/Zona/zonaSagas.js
+++ b/src/store/Zona/zonaSagas.js
@@ -43,8 +43,15 @@ export function* createZone( action ) {
     }else {
       yield put( AppConfigActions.showNotifyToast( "Falha ao criar a zona: " + status, "error" ) );
     }
-  } catch (error) {
-    yield put( AppConfigActions.showNotifyToast( "Erro ao criar a zona, favor verifique sua conexão com a internet", "error" ) );
+  } catch (err) {
+      const {alreadyExist, error} = err.response.data
+
+      yield put( ZonaActions.createZoneFail() )
+
+      if(alreadyExist)
+        yield put( AppConfigActions.showNotifyToast( error, "error" ) );
+      else
+        yield put( AppConfigActions.showNotifyToast( "Erro ao criar a zona, favor verifique sua conexão com a internet", "error" ) );
   }
 }
 


### PR DESCRIPTION
Antes a pagina só permitia alterar se a zona estava ativa ou não

Agora também é possível alterar o nome da zona, sendo que o campo só aceita letras e acentos

Como o nome das zonas em um mesmo município devem ser únicos, a edição não é feita caso o novo nome não respeite está regra

Quanto ao botão do formulário, quando ele é apertado, o mesmo é desabilitado e aparece uma mini tela de carregamento até que a operação de edição seja concluída