### PR TITLE
Ajustes na desabilitação de localidade

### DIFF
--- a/src/pages/Localidades/ModalDisabled.js
+++ b/src/pages/Localidades/ModalDisabled.js
@@ -1,26 +1,29 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Modal, { ModalBody, ModalFooter } from '../../components/Modal';
 import $ from 'jquery';
+import LoadginGif from '../../assets/loading.gif';
 
 // REDUX
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 // ACTIONS
-import { updateLocationRequest, clearUpdate } from '../../store/Localidade/localidadeActions';
+import { updateLocationRequest, clearUpdate, getLocationByCityRequest, } from '../../store/Localidade/localidadeActions';
 
 // STYLES
 import { Button } from '../../styles/global';
 
-function ModalDisabled( props ) {
+function ModalDisabled(props ) {
+  const [ flLoading, setFlLoading ] = useState( false );
+
   function handleClick() {
+    setFlLoading( true );
     props.tableSelected.forEach( row => {
       const { id } = props.localidades[ row.dataIndex ];
 
       props.updateLocationRequest( id, { ativo: 0 } );
     });
-
     props.clearUpdate();
   }
 
@@ -30,6 +33,8 @@ function ModalDisabled( props ) {
 
   useEffect(() => {
     if( props.updated ) {
+      props.getLocationByCityRequest( props.municipio_id );
+      setFlLoading( false );
       $('#modal-desativar-localidade').modal('hide');
     }
   }, [ props.updated ]);
@@ -40,8 +45,34 @@ function ModalDisabled( props ) {
         <p>Deseja desativar a(s) localidade(s)?</p>
       </ModalBody>
       <ModalFooter>
-        <Button className="secondary" data-dismiss="modal">Cancelar</Button>
-        <Button className="danger" onClick={ handleClick }>Confirmar</Button>
+        <Button 
+          className="secondary" 
+          data-dismiss="modal" 
+          disabled={ flLoading }>
+            Cancelar
+        </Button>
+        <Button
+          className="danger"
+          onClick={ handleClick }
+          loading={ flLoading.toString() }
+          disabled={ flLoading ? 'disabled' : '' }
+        >
+          {
+            flLoading ?
+              (
+                <>
+                  <img
+                    src={ LoadginGif }
+                    width="25"
+                    style={{ marginRight: 10 }}
+                    alt="Carregando"
+                  />
+                  Desativando...
+                </>
+              ) :
+              "Confirmar"
+          }
+        </Button>
       </ModalFooter>
     </Modal>
   );
@@ -50,11 +81,12 @@ function ModalDisabled( props ) {
 const mapStateToProps = state => ({
   tableSelected: state.supportInfo.tableSelection.tableLocation,
   localidades: state.localidade.localidades,
-  updated: state.localidade.updated
+  updated: state.localidade.updated,
+  municipio_id: state.appConfig.usuario.municipio.id,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ updateLocationRequest, clearUpdate }, dispatch);
+  bindActionCreators({ updateLocationRequest, clearUpdate, getLocationByCityRequest, }, dispatch);
 
 export default connect(
   mapStateToProps,

--- a/src/pages/Localidades/index.js
+++ b/src/pages/Localidades/index.js
@@ -8,6 +8,7 @@ import Table, { ButtonAdd, ButtonDesabled } from '../../components/Table';
 import ModalAdd from './ModalAdd';
 import ModalDisabled from './ModalDisabled';
 import { FaMapSigns } from 'react-icons/fa';
+import $ from "jquery";
 
 // REDUX
 import { bindActionCreators } from 'redux';
@@ -23,6 +24,8 @@ import { getLocationRequest, getLocationByCityRequest, changeIndex } from '../..
 import { GlobalStyle } from './styles';
 import { PageHeader, PageIcon } from '../../styles/util';
 
+import { ordenadorData } from '../../config/function';
+
 const columns = [
   {
     name: "index",
@@ -30,6 +33,7 @@ const columns = [
     options: {
       filter: false,
       display: 'false',
+      viewColumns: false,
       customBodyRender: (value, tableMeta, updateValue) => {
         return (
           <Typography data-id={ value.id }>{ value.index }</Typography>
@@ -54,7 +58,8 @@ const columns = [
     label: "Criado em",
     options: {
      display: 'false',
-     filter: false
+     filter: false,
+     sortCompare: ordenadorData
     }
   },
   {
@@ -62,7 +67,8 @@ const columns = [
     label: "Atualizado em",
     options: {
      display: 'false',
-     filter: false
+     filter: false,
+     sortCompare: ordenadorData
     }
   },
   {
@@ -90,6 +96,7 @@ const columns = [
 
 const Localidades = ({ municipio_id, localidades, municipio, ...props }) => {
   const [ rows, setRows ] = useState([]);
+  
   const options = {
     customToolbar: () => {
       return (
@@ -103,6 +110,9 @@ const Localidades = ({ municipio_id, localidades, municipio, ...props }) => {
       props.changeTableSelected('tableLocation', data);
       return (
         <ButtonDesabled
+          onClick={() => {
+            $("#modal-desativar-localidade").modal("show");
+          }}
           title="Desabilidade bairro/localidade"
           toggle="modal"
           target="#modal-desativar-localidade" />

--- a/src/pages/Municipios/ModalAdd.js
+++ b/src/pages/Municipios/ModalAdd.js
@@ -161,6 +161,9 @@ function ModalAdd( { createCityRequest, createdCity, show, handleClose, ...props
     <Modal id="modal-novo-municipio" onHide={ handleClose() } title="Cadastrar Município" size='lg'>
       <form onSubmit={ handleCadastrar }>
         <ModalBody>
+        <p className="text-description">
+          Atenção os campos com <code>*</code> são obrigatórios
+        </p>
         <Row>
             <Col sm="6">
               <FormGroup>

--- a/src/pages/Zonas/ModalAdd.js
+++ b/src/pages/Zonas/ModalAdd.js
@@ -64,6 +64,9 @@ function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
     <Modal id="modal-novo-zona" title="Cadastrar Zona">
       <form onSubmit={ handleCadastrar }>
         <ModalBody>
+        <p className="text-description">
+          Atenção os campos com <code>*</code> são obrigatórios
+        </p>
         <Row>
             <Col>
               <FormGroup>


### PR DESCRIPTION
Quando era desabilitado mais de uma localidade, a tabela exibida no site não era atualizada corretamente. Correção foi feita

A coluna # não é mais exibida

O modal de confirmação agora exibe um carregamento ao apertar o botão confirmar