### PR TITLE
Ajustes nos modals de imoveis

### DIFF
--- a/src/pages/Imoveis/components/ModalImovel/index.js
+++ b/src/pages/Imoveis/components/ModalImovel/index.js
@@ -17,7 +17,10 @@ import { addImovelRequest, editarImovelRequest, clearCreate } from '../../../../
 // STYLES
 import { Button, FormGroup, selectDefault } from '../../../../styles/global';
 
-export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) => {
+// VALIDATIONS FUNCTIONS
+import {onlyLetters} from '../../../../config/function';
+
+export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, isOpen, handleClose, ...props }) => {
   const [ imovel_id, setImovelId ]                = useState( null );
   const [ numero, setNumero ]                     = useState( null );
   const [ sequencia, setSequencia ]               = useState( null );
@@ -45,6 +48,18 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
     zoom: 2
   });
   const [ marcador, setMarcador ]                 = useState( {} );
+
+  useEffect(() => {
+    if(isOpen){
+      if( Object.entries( imovel ).length > 0 ){
+        setClss([]);
+        setFlLocValido(true)
+      }
+      else
+        limparCampos()
+    }
+    handleClose()
+  }, [isOpen]);
 
   useEffect(() => {
     props.getQuarteiroesMunicipioRequest( usuario.municipio.id, true );
@@ -123,6 +138,8 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
     setLat( "" );
     setLocalizacao( "" );
     setMarcador( {} );
+    setClss([]);
+    setFlLocValido(true)
   }
 
   const limparClss = index => {
@@ -216,6 +233,24 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
       c         = clss;
 
       c[ 'tipoImovel' ] = 'invalid';
+      setClss( c );
+    }
+
+    if( !lng ) {
+      fl_valido = false;
+      c         = clss;
+
+      c[ 'longitude' ] = 'invalid';
+      setFlLocValido(false)
+      setClss( c );
+    }
+
+    if( !lat ) {
+      fl_valido = false;
+      c         = clss;
+
+      c[ 'latitulde' ] = 'invalid';
+      setFlLocValido(false)
       setClss( c );
     }
 
@@ -330,7 +365,7 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
                   id="responsavel"
                   value={ responsavel }
                   className="form-control"
-                  onChange={ e => setResponsavel( e.target.value ) }
+                  onChange={ e =>( onlyLetters(e.target.value) ?  setResponsavel( e.target.value ) : () => {} )}
                 />
               </FormGroup>
             </Col>
@@ -374,6 +409,7 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
                         className="form-control"
                         value={ localizacao }
                         onChange={ e => checkLocalizacao( e.target.value ) }
+                        onBlur={ () => setFlLocValido(true) }
                       />
                     </div>
                     <div className="toggle-control">
@@ -398,7 +434,8 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
                           type      ="number"
                           pattern   ="[0-9]*"
                           onKeyDown ={ e => [ "e", "E", "+", "," ].includes( e.key ) && e.preventDefault() }
-                          className ="form-control"
+                          className ={ "form-control " + clss[ 'longitude' ] }
+                          onBlur    ={ () => limparClss( 'longitude' ) }
                           onChange  ={ e => { setLng( e.target.value ); checkLocValida( e.target.value, "lng" ); } }
                         />
                       </FormGroup>
@@ -410,7 +447,8 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, ...props }) =
                           type      ="number"
                           pattern   ="[0-9]*"
                           onKeyDown ={ e => [ "e", "E", "+", "," ].includes( e.key ) && e.preventDefault() }
-                          className ="form-control"
+                          className ={ "form-control " + clss[ 'latitulde' ] }
+                          onBlur    ={ () => limparClss( 'latitulde' ) }
                           onChange  ={ e => { setLat( e.target.value ); checkLocValida( e.target.value, "lat" ); } }
                         />
                       </FormGroup>

--- a/src/pages/Imoveis/index.js
+++ b/src/pages/Imoveis/index.js
@@ -88,6 +88,7 @@ const columns = [
 export const Imoveis = ({ imoveis, usuario, ...props }) => {
   const [ rowsSelected, setRowsSelected ] = useState( [] );
   const [ rows, setRows ]                 = useState( [] );
+  const [ isModalOpen, setIsModalOpen]    = useState( false );
   const options = {
     customToolbar: () => {
       return (
@@ -95,7 +96,10 @@ export const Imoveis = ({ imoveis, usuario, ...props }) => {
           title="Adicionar Imóvel"
           data-toggle="modal"
           data-target="#modal-imovel"
-          onClick={ () => props.setImovel( {} ) }
+          onClick={ () => {
+            props.setImovel( {} )
+            setIsModalOpen(true)
+          } }
         />
       );
     },
@@ -134,7 +138,10 @@ export const Imoveis = ({ imoveis, usuario, ...props }) => {
         <Tooltip
             className="bg-warning text-white"
             title="Editar"
-            onClick={ () => handlerImovel( index ) }
+            onClick={ () => {
+              setIsModalOpen(true)
+              handlerImovel( index )
+            } }
           >
             <IconButton aria-label="Editar">
               <FaPenSquare />
@@ -151,6 +158,8 @@ export const Imoveis = ({ imoveis, usuario, ...props }) => {
 
     $( '#modal-imovel' ).modal( 'show' );
   }
+
+  const handleClose = () => {setIsModalOpen(false)}
 
   /**
    * Aciona o action para remover os imóveis
@@ -180,7 +189,7 @@ export const Imoveis = ({ imoveis, usuario, ...props }) => {
               data={ rows }
               options={ options }
             />
-            <ModalImovel />
+            <ModalImovel isOpen={isModalOpen} handleClose={handleClose} />
             <ModalConfirm id="modal-deletar-imovel" title="Deletar Imóvel" confirm={ desativarImoveis }>
               <p>Deseja realmente deletar o(s) imóvel(is)</p>
             </ModalConfirm>

--- a/src/pages/Quarteiroes/components/ModalImovel/index.js
+++ b/src/pages/Quarteiroes/components/ModalImovel/index.js
@@ -7,6 +7,7 @@ import { FaChevronDown, FaChevronUp, FaMapMarkerAlt } from 'react-icons/fa';
 import { Collapse } from 'react-bootstrap';
 import ReactMapGL, { Marker } from 'react-map-gl';
 import { removeMultipleSpaces } from '../../../../config/function';
+import SelectWrap from '../../../../components/SelectWrap'
 
 // Models
 import { Imovel } from '../../../../config/models';
@@ -17,11 +18,14 @@ import { connect } from 'react-redux';
 
 // ACTIONS
 import { setUpdated } from '../../../../store/Quarteirao/quarteiraoActions';
-import { addImovelRequest, editarImovelRequest, clearCreate } from '../../../../store/Imovel/imovelActions';
+import { addImovelRequest, editarImovelRequest, clearCreate, clearUpdate } from '../../../../store/Imovel/imovelActions';
 
 // STYLES
 import { ContainerArrow } from '../../../../styles/util';
 import { Button, FormGroup, selectDefault } from '../../../../styles/global';
+
+// VALIDATIONS FUNCTIONS
+import {onlyLetters} from '../../../../config/function';
 
 /**
  * Modal de adição de um imóvel
@@ -140,8 +144,18 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
       setLado( {} );
       props.clearCreate();
       props.setUpdated( null );
+      setTimeout(() => { document.location.reload( true );}, 1000)
     }
   }, [ props.created ] );
+
+  useEffect( () => {
+    if( props.updated ) {
+      handleClose();
+      //props.setUpdated( null );
+      setTimeout(() => { document.location.reload( true );}, 1000)
+    }
+    props.clearUpdate();
+  }, [ props.updated ] );
 
   /**
    * Valida se a localização inserida é válida
@@ -242,7 +256,7 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
   }
 
   return (
-    <Modal show={show} onHide={handleClose}>
+    <Modal show={show} onHide={handleClose} backdrop="static" keyboard={false} >
       <Modal.Header closeButton>
         <Modal.Title>
           {acao == "cadastrar" ? "Cadastrar" : "Editar"} Imóvel
@@ -256,12 +270,13 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                 <label htmlFor="lado">
                   Lado <code>*</code>
                 </label>
-                <Select
+                <SelectWrap
                   id="lado"
                   value={lado}
                   styles={selectDefault}
                   options={optionLado}
                   onChange={(e) => setLado(e)}
+                  required
                 />
               </FormGroup>
             </Col>
@@ -283,6 +298,7 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                   }
                   onChange={(e) => setNumero(e.target.value)}
                   min="1"
+                  required
                 />
               </FormGroup>
             </Col>
@@ -312,7 +328,7 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                   id="responsavel"
                   value={responsavel}
                   className="form-control"
-                  onChange={(e) => setResponsavel(e.target.value)}
+                  onChange={(e) => ( onlyLetters(e.target.value) ? setResponsavel(e.target.value) : () => {} )}
                 />
               </FormGroup>
             </Col>
@@ -334,12 +350,13 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                 <label>
                   Tipo do imóvel <code>*</code>
                 </label>
-                <Select
+                <SelectWrap
                   id="tipoImovel"
                   value={tipoImovel}
                   styles={selectDefault}
                   options={optionTipoImovel}
                   onChange={(e) => setTipoImovel(e)}
+                  required                 
                 />
               </FormGroup>
             </Col>
@@ -362,6 +379,7 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                         className="form-control"
                         value={localizacao}
                         onChange={(e) => checkLocalizacao(e.target.value)}
+                        required
                       />
                     </div>
                     <div className="toggle-control">
@@ -394,6 +412,7 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                             setLng(e.target.value);
                             checkLocValida(e.target.value, "lng");
                           }}
+                          required
                         />
                       </FormGroup>
                       <FormGroup className="mb-0">
@@ -409,6 +428,7 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
                             setLat(e.target.value);
                             checkLocValida(e.target.value, "lat");
                           }}
+                          required
                         />
                       </FormGroup>
                     </div>
@@ -460,7 +480,8 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
  * @returns
  */
 const mapStateToProps = state => ( {
-  created: state.imovel.created
+  created: state.imovel.created,
+  updated: state.imovel.updated
 } );
 
 /**
@@ -474,6 +495,7 @@ const mapDispatchToProps = dispatch =>
     addImovelRequest,
     editarImovelRequest,
     setUpdated,
+    clearUpdate,
   }, dispatch );
 
 export default connect(

--- a/src/store/Imovel/imovelSagas.js
+++ b/src/store/Imovel/imovelSagas.js
@@ -52,6 +52,7 @@ export function* editarImovel( action ) {
     const { status } = yield call( servico.updateHouseRequest, action.payload.imovel );
 
     if( status === 200 ) {
+      yield put( ImovelActions.setUpdatedTrue() );
       yield put( AppConfigActions.showNotifyToast( "Imóvel atualizado com sucesso!", "success" ) );
     }else {
       yield put( AppConfigActions.showNotifyToast( "Falha ao atualizar imóvel: " + status, "error" ) );


### PR DESCRIPTION
Os modals de adição e edição não estavam fazendo as validações dos campos de maneira correta

Em ambos os modals, os dados não eram limpos quando eram fechados e abertos novamente

Na pagina de edição de quarteirão, o modal de adição de imóvel recarregar a pagina assim que é confimado que o imovel foi salvo