### PR TITLE
Ajustes na rota de imoveis e outros

### DIFF
--- a/src/controllers/QuarteiraoController.js
+++ b/src/controllers/QuarteiraoController.js
@@ -27,6 +27,7 @@ index = async ( req, res ) => {
         association: 'lados',
         attributes: { exclude: [ 'rua_id', 'createdAt', 'updatedAt' ] },
         order: [[ 'numero', 'asc' ]],
+        where:{ativo:true},
         include: [
           {
             association: 'rua',
@@ -35,7 +36,8 @@ index = async ( req, res ) => {
           {
             association: 'imoveis',
             attributes: { exclude: [ 'createdAt', 'updatedAt' ] },
-            order: [[ 'numero', 'asc' ]]
+            order: [[ 'numero', 'asc' ]],
+            where:{ativo:true}
           }
         ]
       }

--- a/src/controllers/RotasController.js
+++ b/src/controllers/RotasController.js
@@ -86,6 +86,7 @@ getRoute = async ( req, res ) => {
         {
           association: 'imoveis',
           where:{
+            ativo:true,
             id: {
               [Op.notIn]: imoveisId
             },
@@ -409,6 +410,7 @@ startRoute = async ( req, res ) => {
       include: [
         {
           association: 'imoveis',
+          ativo:true,
           where:{
             id: {
               [Op.notIn]: imoveisId
@@ -666,7 +668,7 @@ const getOpenRouteByTeam = async ( req, res ) => {
       'r.cep AS rua_cep, ' +
       'r.localidade_id AS rua_localidade_id, ' +
       'CAST( ' +
-        '(SELECT COUNT(*) FROM imoveis WHERE lado_id = l.id) ' +
+        '(SELECT COUNT(*) FROM imoveis WHERE lado_id = l.id AND ativo = true) ' +
       ' AS INTEGER ) AS imoveis, ' +
       'CAST( ' +
         '( ' +
@@ -686,7 +688,7 @@ const getOpenRouteByTeam = async ( req, res ) => {
       'quarteiroes AS q ' +
       'JOIN lados AS l ON(q.id = l.quarteirao_id) ' +
       'JOIN ruas AS r ON(l.rua_id = r.id) ' +
-    'WHERE ';
+    'WHERE l.ativo = true AND ';
       // 'q.id = 1 ' +
       // 'OR q.id = 2';
 


### PR DESCRIPTION
Com relação a rota de imóveis
 -  Na função "getImoveisMunicipios", agora só são mostrados os imoveis que estejam ativos
 - Na função "Destroy", o imóvel só é realmente deletado no caso de não haver nenhuma vistoria vinculada a ele. Caso 
    contrário ele é inativado

Com relação a rotas do quarteirão
  - A função "index" retorna apenas os lados e imóveis ativos do quarteirão desejado

Com relação as rotas da RotasController
 - As funções getRoute e startRoute ignoram os imoveis inativados
 - Na função getOpenRouteByTeam, o sql que contabilizar o número total de imóveis em um lado, agora ignora imóveis 
    inativos