### PR TITLE
Ajustes nas rotas de Rua

### DIFF
--- a/src/controllers/QuarteiraoController.js
+++ b/src/controllers/QuarteiraoController.js
@@ -153,7 +153,8 @@ const findOrCreateStreet = async ( nome, localidade_id, cep ) => {
   const [ rua ] = await Rua.findOrCreate({
     where: {
       nome,
-      localidade_id
+      localidade_id,
+      ativo:true
     },
     defaults: { 
       nome,

--- a/src/database/migrations/20200220232305-create-street.js
+++ b/src/database/migrations/20200220232305-create-street.js
@@ -17,7 +17,6 @@ module.exports = {
         cep: {
           type: Sequelize.STRING,
           allowNull: true,
-          unique: true,
         },
         localidade_id: {
           type: Sequelize.INTEGER,


### PR DESCRIPTION
Na função "getStreetByLocality" agora so é retonado as ruas que estão na localidade informada e que estejam ativas

Na função "update" ao invez de deletar a rua, ela é inativada. Caso existam lados que estam associados a rua em questão, a operação não é feita e é retornado um array "numQuarteirões" que guarda os ids dos qurteirões que contem esse lados

A função auxiliar "ruaExistente" agora faz a verificação apenas com ruas que estejam ativas

No QuarteiraoController, a função "findOrCreateStreet" agora tentar encontrar uma rua pelo nome, localidade e se está ativa

Extra: No Banco foi necessário tirar da tabela Rua o contraint unique da coluna Cep. Isso foi necessário pq como as ruas não são excluídas mas sim inativadas, é possivel existirem 2 ruas com mesmo cep, contanto que apenas no máximo uma delas esteja ativa