### PR TITLE
Ajustes no ruaSaga e no modal de edição de rua

### DIFF
--- a/src/pages/Localidades/ModalUpdateStreet.js
+++ b/src/pages/Localidades/ModalUpdateStreet.js
@@ -102,7 +102,8 @@ function ModalUpdateStreet({ updated, index, show, handleClose, ...props }) {
                   styles={ selectDefault }
                   options={ optionLocalidade }
                   onChange={ e => setLocalidade(e) }
-                  required />
+                  required 
+                  isDisabled={true}/>
               </FormGroup>
             </Col>
           </Row>

--- a/src/store/Rua/ruaSagas.js
+++ b/src/store/Rua/ruaSagas.js
@@ -135,8 +135,21 @@ export function* deleteStreet( action ) {
     }else {
       yield put( AppConfigActions.showNotifyToast( "Falha ao excluir rua: " + status, "error" ) );
     }
-  } catch (error) {
-    yield put( AppConfigActions.showNotifyToast( "Verifique se existem quarteirões associados a essa rua", "warning" ) );
+  } catch (err) {
+
+    if(err.response){
+      const {numQuarteiroes, error} = err.response.data
+
+      //caso um quarteirão com esteja associado com a rua
+      if(numQuarteiroes){
+        yield put( AppConfigActions.showNotifyToast( "Existem lados associados a esta rua que devem ser excluidos antes. Os números dos quarteirões que contem esses lados são: "+numQuarteiroes, "warning" ) );
+      //provavel erro na api ou banco
+      }else
+        yield put( AppConfigActions.showNotifyToast( "Erro ao deletar rua, entre em contato com o suporte", "error" ) );
+    }
+    //Não conseguiu entrar em contato com api
+    else
+      yield put( AppConfigActions.showNotifyToast( "Erro deletar rua, favor verifique sua conexão com a internet", "error" ) );
   }
 }
 


### PR DESCRIPTION
No modal de edição de rua, foi bloqueado o campo localidade, pois permitir a mudança desse campo gerava inconsistências com os lados do quarteirão associados à esta rua

No ruaSaga, o metodo "deleteStreet" foi ajustado para no caso de receber como resposta um array "numQuarteirao", que contem os numeros do quarteirões que possuem lados associados à rua que se deseja inativar.