### PR TITLE
Melhorando a página de listagem de amostras

### DIFF
--- a/src/pages/Amostras/index.js
+++ b/src/pages/Amostras/index.js
@@ -75,10 +75,10 @@ export const Amostras = ({ laboratorios, amostras, usuario, ...props }) => {
   const handleCloseModalExaminar = () => {setOpenModalExaminar(false)}
 
   const options = {
-    //Não permite que amostras com situação positiva ou negativa 
+    //Não permite que amostras com situação positiva, negativa ou encaminhada
     //sejam selecionados para serem encaminhadas
     isRowSelectable: (dataIndex) => {
-      return (rows[dataIndex][5] != "Positiva" && rows[dataIndex][5] != "Negativa")
+      return (rows[dataIndex][5] != "Positiva" && rows[dataIndex][5] != "Negativa" && rows[dataIndex][5] != "Encaminhada")
     },
     customToolbarSelect: () => {
       return (

--- a/src/pages/Rota/PlanejarRota/components/ModalEncerrarAtividade/index.js
+++ b/src/pages/Rota/PlanejarRota/components/ModalEncerrarAtividade/index.js
@@ -24,7 +24,7 @@ function ModalEncerrarAtividade( { atividadeId, ...props } ) {
       props.finishActivityReset();
       $('#'+props.id).modal('hide');
       setTimeout(() => { document.location.reload( true );}, 1500)
-    }else if( props.destroyed === false ) {
+    }else if( props.finished === false ) {
       setFlLoading( false );
       props.finishActivityReset();
     }

--- a/src/store/Amostra/amostraActions.js
+++ b/src/store/Amostra/amostraActions.js
@@ -4,6 +4,9 @@ export const ActionTypes = {
   SET_AMOSTRAS: "SET_AMOSTRAS",
   ENVIAR_AMOSTRAS_REQUEST: "ENVIAR_AMOSTRAS_REQUEST",
   REGISTRAR_EXAME_REQUEST: "REGISTRAR_EXAME_REQUEST",
+  REGISTRAR_EXAME_SUCCESS: "REGISTRAR_EXAME_SUCCESS",
+  REGISTRAR_EXAME_FAIL: "REGISTRAR_EXAME_FAIL",
+  REGISTRAR_EXAME_RESET: "REGISTRAR_EXAME_RESET",
   SET_AMOSTRA: "SET_AMOSTRA"
 }
 
@@ -73,6 +76,24 @@ export const registrarExameRequest = exame => {
     payload: {
       exame
     }
+  }
+}
+
+export const registrarExameSuccess = () => {
+  return {
+    type: ActionTypes.REGISTRAR_EXAME_SUCCESS,
+  }
+}
+
+export const registrarExameFail = () => {
+  return {
+    type: ActionTypes.REGISTRAR_EXAME_FAIL,
+  }
+}
+
+export const registrarExameReset = () => {
+  return {
+    type: ActionTypes.REGISTRAR_EXAME_RESET,
   }
 }
 

--- a/src/store/Amostra/amostraReduce.js
+++ b/src/store/Amostra/amostraReduce.js
@@ -3,7 +3,8 @@ import { ActionTypes } from './amostraActions';
 const INITIAL_STATE = {
   amostra: {},
   amostras: [],
-  reload: false
+  reload: false,
+  exameSalvo: null,
 }
 
 export default function Amostra(state = INITIAL_STATE, action) {
@@ -19,6 +20,24 @@ export default function Amostra(state = INITIAL_STATE, action) {
       return {
         ...state,
         amostra: action.payload.amostra
+      };
+    
+    case ActionTypes.REGISTRAR_EXAME_SUCCESS:
+      return {
+        ...state,
+        exameSalvo: true
+      };
+    
+    case ActionTypes.REGISTRAR_EXAME_FAIL:
+      return {
+        ...state,
+        exameSalvo: false
+      };
+    
+    case ActionTypes.REGISTRAR_EXAME_RESET:
+      return {
+        ...state,
+        exameSalvo: null
       };
 
     default:

--- a/src/store/Amostra/amostraSagas.js
+++ b/src/store/Amostra/amostraSagas.js
@@ -72,11 +72,12 @@ export function* registrarExame( action ) {
     const { status } = yield call( servico.registrarExameRequest, action.payload );
 
     if( status === 200 ) {
-      document.location.reload();
+      yield put( AmostraActions.registrarExameSuccess() );
     }else {
       yield put( AppConfigActions.showNotifyToast( "Falha ao registrar exame: " + status, "error" ) );
     }
   } catch (err) {
+    yield put( AmostraActions.registrarExameFail() );
     if(err.response){
       //Provavel erro de logica na API
       yield put( AppConfigActions.showNotifyToast( "Erro ao registar exame, entre em contato com o suporte", "error" ) );

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -101,6 +101,12 @@ export const GlobalStyle = createGlobalStyle`
     box-shadow: none!important;
   }
 
+  .expansion_error {
+    border: 1px solid #fc2403;
+    border-radius: 0.1875rem!important;
+    box-shadow: none!important;
+  }
+
   .table-rounded-none {
     box-shadow: none!important;
   }


### PR DESCRIPTION
Na listagem de amostras do supervisor:

1 - Agora amostras com com a situação "encaminhada" não pode se encaminhada novamente

Sobre o modal de examinar amostra

1 - Ao selecionar o campo "Positivo para algum mosquito" como "Sim", é obrigatório que seja adicionado ao menos um exame na amostra

2 -  Ao selecionar o campo "Positivo para algum mosquito" como "Não",  não é possível adicionar exames na amostra, já que não houve presença de nenhum traço de mosquito

3 - Os exames adicionados devem informa qual o tipo de mosquito encontrado, caso contrario é exibido uma mensagem de erro

4 - Ao apertar o botão salvar, o botão exibe um carregamento indicando que a operação está sendo feita. Caso a operação seja bem sucedida, é exibido uma mensagem de sucesso