### PR TITLE
Mudança de algumas regras da pagina

### DIFF
--- a/src/components/ModalExaminarAmostra/index.js
+++ b/src/components/ModalExaminarAmostra/index.js
@@ -110,7 +110,7 @@ export const ModalExaminarAmostra = ({ mosquitos, amostra, isOpen, handleClose, 
 
   useEffect(() => {
     if( props.exameSalvo ) {
-      props.showNotifyToast("Amostrar examinada com sucesso", "success")
+      props.showNotifyToast("Amostra examinada com sucesso", "success")
       setTimeout(() => { document.location.reload( true );}, 2000)
     }
     setFlLoading(false)


### PR DESCRIPTION
Amostras com a situação encaminhada, não pode ser examinada pelo supervisor, devendo aguardar o resultado do laboratório. Para saber em qual laboratório a amostra foi enviada, basta aperta o botão na coluna 'Ações'

Com o uso do modal 'ModalExaminarAmostras' as amostras só podem ser examinadas uma única vez.

Os ícones das colunas de ações variam de acordo com a situação da amostra

Agora a tabela também exibe o código da atividade que a amostra foi coletada