### PR TITLE
Ajustes na página de inicialização de rotas

### DIFF
--- a/src/services/requests/Rota.js
+++ b/src/services/requests/Rota.js
@@ -7,6 +7,13 @@ export const getRouteRequest = data => {
   });
 }
 
+export const getRoutesRequest = data => {
+  const { usuario_id, dia } = data;
+  return api.get(`/rotas/todas/${ usuario_id }/usuarios/${ dia }/data`, {
+    ...headerAuthorization()
+  });
+}
+
 export const getRotasPlanejadasRequest = data => {
   const { usuario_id, ciclo_id } = data;
   return api.get(`/rotas/planejadas/${ ciclo_id }/ciclo/${ usuario_id }/supervisor`, {

--- a/src/store/Rota/rotaActions.js
+++ b/src/store/Rota/rotaActions.js
@@ -15,7 +15,7 @@ export const ActionTypes = {
   SALVAR_ROTA: "SALVAR_ROTA",
   RESETAR_OPENMODAL: "RESETAR_OPENMODAL",
   SET_AUX_FINALIZADO: "SET_AUX_FINALIZADO,",
-  SET_AUX_INICIADO: "SET_AUX_INICIADO"
+  SET_ROTA_INICIADA: "SET_ROTA_INICIADA"
 }
 
 /**
@@ -208,18 +208,24 @@ export const setAuxFinalizado = auxFinalizado => {
 }
 
 /**
- * Solicita ao reduce que altere a variável auxIniciado
- * auxInicado é um estado auxiliar para quando o trabalho
- * diario for iniciado, com o intuito de não interferir como
- * a variavel fl_iniciada
- * @param {boolean} AuxFinalizado 
- * @returns 
+ * Após a requisição para iniciar uma rota, essa action
+ * é chamada para indica ser o processo foi bem sucedido
+ * ou não.
+ * 
+ * Ela recebe um boolean ' rotaIniciada' que pode receber 3 valores:
+ * 
+ * true  - Requisição foi bem sucedisa
+ * false - Requisição não ocorreu ou houve alguma falha.
+ * undefined || null - Estado padrão, significa que nenhum requisição foi feita
+ *
+ * @param {Bollean} fl_carregando_rota
+ * @returns
  */
-export const setAuxIniciado = auxIniciado => {
+export const setRotaIniciada = rotaIniciada => {
   return {
-    type    : ActionTypes.SET_AUX_INICIADO,
+    type    : ActionTypes.SET_ROTA_INICIADA,
     payload : {
-      auxIniciado
+      rotaIniciada
     }
   }
 }

--- a/src/store/Rota/rotaReduce.js
+++ b/src/store/Rota/rotaReduce.js
@@ -15,7 +15,7 @@ const INITIAL_STATE = {
    * o estado isFinalizado
   */
   auxFinalizado: undefined,
-  auxIniciado: undefined  
+  rotaIniciada: undefined  
 }
 
 export default function Rota(state = INITIAL_STATE, action) {
@@ -92,10 +92,10 @@ export default function Rota(state = INITIAL_STATE, action) {
         ...state,
         auxFinalizado: action.payload.auxFinalizado,
       };
-    case ActionTypes.SET_AUX_INICIADO:
+    case ActionTypes.SET_ROTA_INICIADA:
       return {
         ...state,
-        auxIniciado: action.payload.auxFinalizado,
+        rotaIniciada: action.payload.rotaIniciada,
       };
 
     default:

--- a/src/store/Rota/rotaSagas.js
+++ b/src/store/Rota/rotaSagas.js
@@ -73,9 +73,9 @@ export function* getRotasPlanejadas(action) {
   }
 }
 
-export function* getRoute(action) {
+export function* getRoutes(action) {
   try {
-    const { data, status } = yield call( service.getRouteRequest, action.payload );
+    const { data, status } = yield call( service.getRoutesRequest, action.payload );
 
     if( status === 200 ) {
       yield put( RotaCacheActions.getRoute( data ) );
@@ -127,16 +127,16 @@ export function* startRoute(action) {
       //Linha abaixo foi comentada porque não é necessario limpar as vistorias de um trabalho que acabou de começar, ou seja, não possui vistorias ainda
       //yield put( VistoriaCacheActions.clearInspection(null) );
 
-      yield put( RotaActions.setAuxIniciado(true) );
-      window.location = window.location.origin.toString() + '/vistoria';
+      yield put( RotaActions.setRotaIniciada(true) );
+      //window.location = window.location.origin.toString() + '/vistoria';
     }else {
-      yield put( RotaActions.setAuxIniciado(false) );
+      yield put( RotaActions.setRotaIniciada(false) );
       yield put( AppConfigActions.showNotifyToast( "Falha ao iniciar rota: " + status, "error" ) );
     }
 
   } catch (err) {
 
-    yield put( RotaActions.setAuxIniciado(false) );
+    yield put( RotaActions.setRotaIniciada(false) );
 
     if(err.response){
       //Provavel erro de logica na API
@@ -206,7 +206,7 @@ function* watchIsFinalizado() {
 }
 
 function* watchGetRoute() {
-  yield takeLatest( RotaActions.ActionTypes.GET_ROUTE_REQUEST, getRoute );
+  yield takeLatest( RotaActions.ActionTypes.GET_ROUTE_REQUEST, getRoutes );
 }
 
 function* watchIsStarted() {

--- a/src/store/RotaCache/rotaCacheActions.js
+++ b/src/store/RotaCache/rotaCacheActions.js
@@ -7,7 +7,8 @@ export const ActionTypes = {
   ENCERRAR_ROTA_REQUEST: "ENCERRAR_ROTA_REQUEST",
   SALVAR_ROTA: "SALVAR_ROTA",
   RESETAR_OPENMODAL: "RESETAR_OPENMODAL",
-  CLEAR_ROTA_CACHE: "CLEAR_ROTA_CACHE",
+  CLEAR_TRABALHO_ROTA_CACHE: "CLEAR_TRABALHO_ROTA_CACHE",
+  SET_TRABALHO_ROTA_CACHE: "SET_TRABALHO_ROTA_CACHE"
 }
 
 export const resetOpenModal = () => {
@@ -88,8 +89,23 @@ export const closeRouteRequest = ( trabalhoDiario_id, horaFim, vistorias ) => {
  * Limpa o cache da rota
  * @returns 
  */
-export const clearRotaCache = () => {
+export const clearTrabalhoRotaCache = () => {
   return {
-    type: ActionTypes.CLEAR_ROTA_CACHE
+    type: ActionTypes.CLEAR_TRABALHO_ROTA_CACHE
+  }
+}
+
+/**
+ * Seta no cache a rota e o respectivo trabalho diario que foi
+ * escolhido pelo usuario
+ * @returns 
+ */
+export const setTrabalhoRotaCache = ( trabalhoDiario, rota ) => {
+  return {
+    type: ActionTypes.SET_TRABALHO_ROTA_CACHE,
+    payload: {
+      trabalhoDiario,
+      rota,
+    }
   }
 }

--- a/src/store/RotaCache/rotaCacheReduce.js
+++ b/src/store/RotaCache/rotaCacheReduce.js
@@ -6,7 +6,8 @@ const INITIAL_STATE = {
   trabalhoDiario: {
     data: ""
   },
-  rota: []
+  rota: [],
+  todosTrabalhosRotas:[]
 }
 
 export default function RotaCache( state = INITIAL_STATE, action ) {
@@ -30,19 +31,25 @@ export default function RotaCache( state = INITIAL_STATE, action ) {
     }
 
     case ActionTypes.GET_ROUTE_SUCCESS: {
-      const { data }      = action.payload;
-      let trabalhoDiario  = INITIAL_STATE.trabalhoDiario;
-      let rota            = INITIAL_STATE.rota;
+      const { data }          = action.payload;
+      let trabalhoDiario      = INITIAL_STATE.trabalhoDiario;
+      let rota                = INITIAL_STATE.rota;
+      let todosTrabalhosRotas = INITIAL_STATE.todosTrabalhosRotas
 
-      if( typeof data.trabalhoDiario !== 'undefined' ) {
+      if( data.length > 0 ) {
+        todosTrabalhosRotas = data
+      }
+
+     /*  if( data.trabalhoDiario !== 'undefined' ) {
         trabalhoDiario  = data.trabalhoDiario;
         rota            = data.rota;
-      }
+      } */
 
       return {
         ...state,
         trabalhoDiario,
-        rota
+        rota,
+        todosTrabalhosRotas
       }
     }
 
@@ -54,10 +61,19 @@ export default function RotaCache( state = INITIAL_STATE, action ) {
       }
     }
 
-    case ActionTypes.CLEAR_ROTA_CACHE: {
+    case ActionTypes.CLEAR_TRABALHO_ROTA_CACHE: {
       return {
         ...state,
-        ...INITIAL_STATE,
+        trabalhoDiario:INITIAL_STATE.trabalhoDiario,
+        rota:INITIAL_STATE.rota
+      }
+    }
+
+    case ActionTypes.SET_TRABALHO_ROTA_CACHE: {
+      return {
+        ...state,
+        rota: action.payload.rota,
+        trabalhoDiario: action.payload.trabalhoDiario,
       }
     }
 


### PR DESCRIPTION
Antes deste commit, o usuario não conseguia escolher a rota diária o qual ele queria iniciar primeiro.

Agora o usuário recebe uma lista de atividades cujo possuem trabalho diário para hoje. Ao escolher o código da atividade que contem a rota que ele deseja iniciar,  o sistema irá mostrar os imóveis que serão vistoriados e libera a inicialização da rota