### PR TITLE
Permite escolha da rota para vistoriar

### DIFF
--- a/src/components/LoadingPage/index.js
+++ b/src/components/LoadingPage/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Backdrop from '@material-ui/core/Backdrop';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+export const LoadingPage = ({ element, ...props }) => {
+    return(
+        <Backdrop
+            sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
+            open
+        >
+            <CircularProgress color="inherit" />
+        </Backdrop>
+    )
+}
+  
+export default LoadingPage;

--- a/src/components/ModalFinalizarTrabalho/index.js
+++ b/src/components/ModalFinalizarTrabalho/index.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 // ACTIONS
-import { closeRouteRequest, getRouteRequest, setAuxFinalizado } from '../../store/Rota/rotaActions';
+import { closeRouteRequest, setAuxFinalizado } from '../../store/Rota/rotaActions';
 import { showNotifyToast } from '../../store/AppConfig/appConfigActions';
 
 // import { Container } from './styles';
@@ -48,8 +48,11 @@ function ModalFinalizarTrabalho({ usuario, vistoriasCache, trabalhoDiario, ativi
   //Effect que verifica se as rotas foram finalizadas
   //responsavel por desativar o carregamento do botão Encerrar
   useEffect(() => {
-    if(props.auxFinalizado)
+    if(props.auxFinalizado){
+      props.showNotifyToast( "Rota finalizada e vistorias registradas com sucesso!", "success" )
+      setTimeout(() => { document.location.reload( true );}, 1000)
       $( "#"+props.id ).modal( 'hide' );
+    }
     setFlLoading (false)
     props.setAuxFinalizado( undefined );
   }, [ props.auxFinalizado ]);
@@ -155,7 +158,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ closeRouteRequest, getRouteRequest, showNotifyToast, setAuxFinalizado }, dispatch);
+  bindActionCreators({ closeRouteRequest, showNotifyToast, setAuxFinalizado }, dispatch);
 
 export default connect(
   mapStateToProps,

--- a/src/pages/Dashboard/Municipal/index.js
+++ b/src/pages/Dashboard/Municipal/index.js
@@ -9,7 +9,7 @@ import $ from 'jquery';
 
 // ACTIONS
 import { changeSidebar } from '../../../store/Sidebar/sidebarActions';
-import { getRouteRequest } from '../../../store/Rota/rotaActions';
+import { getRoutesRequest } from '../../../store/Rota/rotaActions';
 import { setAcabouDeLogar } from '../../../store/AppConfig/appConfigActions';
 
 // STYLES
@@ -33,7 +33,7 @@ export const HomeSupervisor = ({ ...props }) => {
     if(props.acabouDeLogar){
       const [ d, m, Y ]  = new Date().toLocaleDateString().split( '/' );
       const current_date = `${ Y }-${ m }-${ d }`;
-      props.getRouteRequest( props.usuario.id, current_date );
+      props.getRoutesRequest( props.usuario.id, current_date );
     }
     props.setAcabouDeLogar(false)
   }, [props.acabouDeLogar]);
@@ -87,7 +87,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   changeSidebar,
   setAcabouDeLogar,
-  getRouteRequest,
+  getRoutesRequest,
 }
 
 export default connect(

--- a/src/store/Rota/rotaActions.js
+++ b/src/store/Rota/rotaActions.js
@@ -6,8 +6,10 @@ export const ActionTypes = {
   SET_ROTAS_PLANEJADAS        : "SET_ROTAS_PLANEJADAS",
   IS_FINALIZADO_REQUEST       : "IS_FINALIZADO_REQUEST",
   SET_IS_FINALIZADO           : "SET_IS_FINALIZADO",
-  GET_ROUTE_REQUEST: "GET_ROUTE_REQUEST",
-  GET_ROUTE_SUCCESS: "GET_ROUTE_SUCCESS",
+  GET_ROUTES_REQUEST: "GET_ROUTE_REQUEST",
+  GET_ROUTES_SUCCESS: "GET_ROUTES_SUCCESS",
+  GET_ROUTES_FAIL:    "GET_ROUTES_FAIL",
+  GET_ROUTES_RESET:   "GET_ROUTES_RESET",
   CHECK_ROTA_INICIADA_REQUEST: "CHECK_ROTA_INICIADA_REQUEST",
   CHECK_ROTA_INICIADA_SUCCESS: "CHECK_ROTA_INICIADA_SUCCESS",
   INICIAR_ROTA_REQUEST: "INICIAR_ROTA_REQUEST",
@@ -131,9 +133,9 @@ export const saveRoute = ( rota, horaInicio ) => {
   }
 }
 
-export const getRouteRequest = ( usuario_id, dia ) => {
+export const getRoutesRequest = ( usuario_id, dia ) => {
   return {
-    type: ActionTypes.GET_ROUTE_REQUEST,
+    type: ActionTypes.GET_ROUTES_REQUEST,
     payload: {
       usuario_id,
       dia
@@ -141,12 +143,21 @@ export const getRouteRequest = ( usuario_id, dia ) => {
   }
 }
 
-export const getRoute = data => {
+export const getRoutesSuccess = () => {
   return {
-    type: ActionTypes.GET_ROUTE_SUCCESS,
-    payload: {
-      data
-    }
+    type: ActionTypes.GET_ROUTES_SUCCESS,
+  }
+}
+
+export const getRoutesFail = () => {
+  return {
+    type: ActionTypes.GET_ROUTES_FAIL,
+  }
+}
+
+export const getRoutesReset = () => {
+  return {
+    type: ActionTypes.GET_ROUTES_RESET,
   }
 }
 

--- a/src/store/Rota/rotaReduce.js
+++ b/src/store/Rota/rotaReduce.js
@@ -15,7 +15,8 @@ const INITIAL_STATE = {
    * o estado isFinalizado
   */
   auxFinalizado: undefined,
-  rotaIniciada: undefined  
+  rotaIniciada: undefined,
+  fl_rotas_encontradas: undefined,
 }
 
 export default function Rota(state = INITIAL_STATE, action) {
@@ -62,23 +63,26 @@ export default function Rota(state = INITIAL_STATE, action) {
       }
     }
 
-    case ActionTypes.GET_ROUTE_SUCCESS: {
-      const { data } = action.payload;
-      let trabalhoDiario = INITIAL_STATE.trabalhoDiario;
-      let rota = INITIAL_STATE.rota;
-
-      if( typeof data.trabalhoDiario !== 'undefined' ) {
-        trabalhoDiario = data.trabalhoDiario;
-        rota = data.rota;
-      }
-
-
+    case ActionTypes.GET_ROUTES_SUCCESS: {
       return {
         ...state,
-        trabalhoDiario,
-        rota
+        fl_rotas_encontradas:true
       }
     }
+
+    case ActionTypes.GET_ROUTES_FAIL: {
+       return {
+         ...state,
+         fl_rotas_encontradas:false
+       }
+     }
+    
+     case ActionTypes.GET_ROUTES_RESET: {
+      return {
+        ...state,
+        fl_rotas_encontradas:undefined
+      }
+    } 
 
     case ActionTypes.CHECK_ROTA_INICIADA_SUCCESS: {
       return {

--- a/src/store/Rota/rotaSagas.js
+++ b/src/store/Rota/rotaSagas.js
@@ -73,17 +73,23 @@ export function* getRotasPlanejadas(action) {
   }
 }
 
+//Busca todas as rotas do usuarios que foram passadas hoje
 export function* getRoutes(action) {
   try {
     const { data, status } = yield call( service.getRoutesRequest, action.payload );
 
     if( status === 200 ) {
       yield put( RotaCacheActions.getRoute( data ) );
+      yield put( RotaActions.getRoutesSuccess() );
     }else {
+      yield put( RotaActions.getRoutesFail() );
       yield put( AppConfigActions.showNotifyToast( "Falha ao consultar a rota: " + status, "error" ) );
     }
 
   } catch (err) {
+
+    yield put( RotaActions.getRoutesFail() );
+
     if(err.response){
       //Provavel erro de logica na API
       yield put( AppConfigActions.showNotifyToast( "Erro ao consultar a rota, entre em contato com o suporte", "error" ) );
@@ -159,10 +165,9 @@ export function* closeRoute(action) {
         const current_date = `${Y}-${m}-${d}`;
         const { data } = yield call( service.getRouteRequest, { usuario_id: action.payload.usuario_id, dia: current_date } );
 
-        yield put( RotaCacheActions.getRoute( data ) );
+        //yield put( RotaCacheActions.getRoute( data ) );
         yield put( VistoriaCacheActions.clearInspection(action.payload.trabalhoDiario_id) );
         yield put( RotaActions.setAuxFinalizado(true) );
-        yield put( AppConfigActions.showNotifyToast( "Rota finalizada e vistorias registradas com sucesso!", "success" ) );
 
         //linha abaixo foi comentado porque o redirecionamento não permitia a limpeza da barra de progressão de vistorias
 
@@ -206,7 +211,7 @@ function* watchIsFinalizado() {
 }
 
 function* watchGetRoute() {
-  yield takeLatest( RotaActions.ActionTypes.GET_ROUTE_REQUEST, getRoutes );
+  yield takeLatest( RotaActions.ActionTypes.GET_ROUTES_REQUEST, getRoutes );
 }
 
 function* watchIsStarted() {

--- a/src/store/RotaCache/rotaCacheReduce.js
+++ b/src/store/RotaCache/rotaCacheReduce.js
@@ -7,7 +7,7 @@ const INITIAL_STATE = {
     data: ""
   },
   rota: [],
-  todosTrabalhosRotas:[]
+  todosTrabalhosRotas:[], // lista que contem todos os trabalhos diarios da data atual junto com suas repectivas rotas
 }
 
 export default function RotaCache( state = INITIAL_STATE, action ) {
@@ -32,8 +32,6 @@ export default function RotaCache( state = INITIAL_STATE, action ) {
 
     case ActionTypes.GET_ROUTE_SUCCESS: {
       const { data }          = action.payload;
-      let trabalhoDiario      = INITIAL_STATE.trabalhoDiario;
-      let rota                = INITIAL_STATE.rota;
       let todosTrabalhosRotas = INITIAL_STATE.todosTrabalhosRotas
 
       if( data.length > 0 ) {
@@ -47,8 +45,6 @@ export default function RotaCache( state = INITIAL_STATE, action ) {
 
       return {
         ...state,
-        trabalhoDiario,
-        rota,
         todosTrabalhosRotas
       }
     }


### PR DESCRIPTION
Antes deste commit, o usuário não tinha liberdade de escolhe a rota o qual ele queria fazer as vistorias, sendo que o sistema obrigava seguir uma ordem pré-determinada

Agora o usuário seleciona qual a rota deseja fazer através da seleção da atividade que contem a rota

Também foi adicionado uma tela de carregamento  nas paginas de vistorias de rota. Ela é exibida enquanto a API não envia resposta da requisição necessária para montar a pagina