### PR TITLE
Ajustes na manutenção de imoveis

### DIFF
--- a/src/pages/Imoveis/components/ModalImovel/index.js
+++ b/src/pages/Imoveis/components/ModalImovel/index.js
@@ -48,12 +48,13 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, isOpen, handl
     zoom: 2
   });
   const [ marcador, setMarcador ]                 = useState( {} );
+  const [ flRecoverInputs, setFlRecoverInputs ]   = useState( true );
 
   useEffect(() => {
     if(isOpen){
       if( Object.entries( imovel ).length > 0 ){
-        setClss([]);
-        setFlLocValido(true)
+        limparCampos()
+        setFlRecoverInputs(!flRecoverInputs)
       }
       else
         limparCampos()
@@ -91,7 +92,7 @@ export const ModalImovel = ({ lados, quarteiroes, usuario, imovel, isOpen, handl
     } else {
       limparCampos();
     }
-  }, [ imovel ]);
+  }, [ imovel, flRecoverInputs ]);
 
   /**
    * Esse effect analisa se o imóvel foi criado, se sim limpa os dados e fecha o

--- a/src/pages/Quarteiroes/components/ModalImovel/index.js
+++ b/src/pages/Quarteiroes/components/ModalImovel/index.js
@@ -19,6 +19,7 @@ import { connect } from 'react-redux';
 // ACTIONS
 import { setUpdated } from '../../../../store/Quarteirao/quarteiraoActions';
 import { addImovelRequest, editarImovelRequest, clearCreate, clearUpdate } from '../../../../store/Imovel/imovelActions';
+import { showNotifyToast } from "../../../../store/AppConfig/appConfigActions";
 
 // STYLES
 import { ContainerArrow } from '../../../../styles/util';
@@ -99,7 +100,6 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
         } )
       );
       setLado( {} );
-      setOptionLado( [] );
       setFlLocValido( true );
       setLocalizacao( "" );
       setFlOpen( false );
@@ -240,18 +240,35 @@ const ModalImovel = ( { acao, imovel, show, handleClose, lados, ...props } ) => 
     });
 
     if( acao === 'cadastrar' ) {
-      props.addImovelRequest({
-        numero,
-        sequencia,
-        responsavel: removeMultipleSpaces(responsavel),
-        complemento: removeMultipleSpaces(complemento),
-        tipoImovel: tipoImovel.value,
-        lado_id: lado.value,
-        lng,
-        lat,
-      });
+      var corner = lados.find( l => l.id == im.lado_id)
+      const numeroRepetido = corner.imoveis.findIndex( imovel => imovel.numero == im.numero)
+
+      if(numeroRepetido != -1)
+        props.showNotifyToast("O número informado já pertence a outro imóvel deste lado",'warning')
+      else{
+        props.addImovelRequest({
+          numero,
+          sequencia,
+          responsavel: removeMultipleSpaces(responsavel),
+          complemento: removeMultipleSpaces(complemento),
+          tipoImovel: tipoImovel.value,
+          lado_id: lado.value,
+          lng,
+          lat,
+        });
+      }
     } else {
-      props.editarImovelRequest( im );
+      var corner = lados.find( l => l.id == im.lado_id)
+
+      //retira o imovel que será alterado, evitando que se compare consigo mesmo
+      var filtrarImoveis = corner.imoveis.filter(imovel => imovel.id != im.id)
+
+      const numeroRepetido = filtrarImoveis.findIndex( imovel => imovel.numero == im.numero)
+
+      if(numeroRepetido != -1)
+        props.showNotifyToast("O número informado já pertence a outro imóvel deste lado",'warning')
+      else
+        props.editarImovelRequest( im );
     }
   }
 
@@ -496,6 +513,7 @@ const mapDispatchToProps = dispatch =>
     editarImovelRequest,
     setUpdated,
     clearUpdate,
+    showNotifyToast,
   }, dispatch );
 
 export default connect(

--- a/src/store/Imovel/imovelSagas.js
+++ b/src/store/Imovel/imovelSagas.js
@@ -47,8 +47,16 @@ export function* addImovel( action ) {
 
   } catch (err) {
     if(err.response){
-      //Provavel erro de logica na API
-      yield put( AppConfigActions.showNotifyToast( "Erro ao adicionar imóvel, entre em contato com o suporte", "error" ) );
+
+      const {numeroRepetido, error} = err.response.data
+
+      if(numeroRepetido)
+        yield put( AppConfigActions.showNotifyToast( "O número do imovel informado já é usado por outro imovél do logradouro", "error" ) );
+      
+      else{
+        //Provavel erro de logica na API
+        yield put( AppConfigActions.showNotifyToast( "Erro ao adicionar imóvel, entre em contato com o suporte", "error" ) );
+      }
       
     }
     //Se chegou aqui, significa que não houve resposta da API
@@ -68,14 +76,23 @@ export function* editarImovel( action ) {
     if( status === 200 ) {
       yield put( ImovelActions.setUpdatedTrue() );
       yield put( AppConfigActions.showNotifyToast( "Imóvel atualizado com sucesso!", "success" ) );
+      setTimeout(() => { document.location.reload( true );}, 1000)
     }else {
       yield put( AppConfigActions.showNotifyToast( "Falha ao atualizar imóvel: " + status, "error" ) );
     }
 
   } catch (err) {
     if(err.response){
-      //Provavel erro de logica na API
-      yield put( AppConfigActions.showNotifyToast( "Erro ao atualizar imóvel, entre em contato com o suporte", "error" ) );
+
+      const {numeroRepetido, error} = err.response.data
+
+      if(numeroRepetido)
+        yield put( AppConfigActions.showNotifyToast( "O número do imovel informado já é usado por outro imovél do logradouro", "error" ) );
+
+      else{
+        //Provavel erro de logica na API
+        yield put( AppConfigActions.showNotifyToast( "Erro ao atualizar imóvel, entre em contato com o suporte", "error" ) );
+      }
       
     }
     //Se chegou aqui, significa que não houve resposta da API


### PR DESCRIPTION
Tanto na pagina de imóveis quanto na pagina de edição de quarteirões, que permitem a adição e edição de imóveis, estava acontecendo o seguinte:

Estava sendo permitido cadastra/editar um imovel com numero que já estava sendo utilizado por outro imovel no mesmo logradouro. Este commit corrigiu essa situação