### PR TITLE
Correção boletim diário

### DIFF
--- a/src/pages/Relatorio/BoletimDiario/index.js
+++ b/src/pages/Relatorio/BoletimDiario/index.js
@@ -204,11 +204,11 @@ function BoletimDiario({ usuario, vistorias, trabalhoDiario, ...props }) {
             break;
         }
       });
+      if( vistoria.depositos.length > 0 )qtdInspecionado++
 
       if( fl_tratado ) qtdTratado++;
 
-      if( vistoria.situacaoVistoria === "N" ) qtdInspecionado++;
-      else qtdRecuperado++;
+      if( vistoria.situacaoVistoria === "R" ) qtdRecuperado++;
 
       qtdTrabalhados++;
 


### PR DESCRIPTION
No gráfico "Imoveis", o número de imóveis inspecionados estava incorreto,  sendo contabilizado os imóveis que tiveram vistoria com a situação do tipo Normal, quando na verdade deveria contabiliza imóveis que tiveram ao menos 1 deposito cadastrado na vistoria