### PR TITLE
Automação do status de visita na vistoria PNCD

### DIFF
--- a/src/pages/Vistoria/components/InspecionarRecipiente/index.js
+++ b/src/pages/Vistoria/components/InspecionarRecipiente/index.js
@@ -46,7 +46,9 @@ function InspecionarRecipiente({ sequenciaRecipiente, inspectionSequence, vistor
             title="Cadastrar Inspeção"
             data-toggle="modal"
             onClick={() => {
-              if(vistoriaPendente)
+              if(vistoriaPendente === "inv")
+                props.showNotifyToast( "Por favor selecione o valor do campo pendência!", "warning" );
+              else if(vistoriaPendente === "F" || vistoriaPendente === "R")
                 props.showNotifyToast( "Vistoria com pendência fechada ou recusada não pode ter depositos cadastrados!", "warning" );
               else 
                 $( '#modalCadastrarInspecao' ).modal( 'show' )

--- a/src/pages/Vistoria/components/ProcurarImovel/index.js
+++ b/src/pages/Vistoria/components/ProcurarImovel/index.js
@@ -18,7 +18,7 @@ import { tipoImovel as tipoImovelEnum } from '../../../../config/enumerate';
 import { selectDefault } from '../../../../styles/global';
 import { Container, UlImovel, LiImovel, ContainerIcon, DivDescription, LiEmpty, Span } from './styles';
 
-function ProcurarImovel({ imovel, selectQuarteirao, rota, quarteirao, isPaginaEdicao, trabalhoDiario_id, ...props }) {
+function ProcurarImovel({ imovel, selectQuarteirao, rota, quarteirao, isPaginaEdicao, trabalhoDiario_id, loadingStatusVistoria, ...props }) {
   const [ optionQuarteirao, setOptionQuarteirao ] = useState([]);
   const [ numero, setNumero ] = useState("");
   const [ sequencia, setSequencia ] = useState("");
@@ -288,14 +288,16 @@ function ProcurarImovel({ imovel, selectQuarteirao, rota, quarteirao, isPaginaEd
             handleImovel={ handleImovel }
             numero={ numero === "" ? "-1" : numero }
             sequencia={ sequencia === "" ? "-1" : sequencia }
-            vistorias={ vistoriasFiltradas } />
+            vistorias={ vistoriasFiltradas } 
+            loadingStatusVistoria={loadingStatusVistoria}
+            />
         </Col>
       </Row>
     </Container>
   );
 }
 
-function ListImovel({ rotaIndex, idImovelSelect, quarteirao, imoveis, ...props }) {
+function ListImovel({ rotaIndex, idImovelSelect, quarteirao, imoveis, loadingStatusVistoria, ...props }) {
   const numero = parseInt( props.numero );
   const sequencia = parseInt( props.sequencia );
 
@@ -315,10 +317,10 @@ function ListImovel({ rotaIndex, idImovelSelect, quarteirao, imoveis, ...props }
     return (
       <LiImovel
         key={ index}
-        className={ `${ idImovelSelect === imovel.id ? "active" : imovel.fl_inspection ? " disabled" : "" }` }
+        className={ `${ idImovelSelect === imovel.id ? "active" : imovel.fl_inspection || loadingStatusVistoria ? " disabled" : "" }` }
         onClick={ () => {
           if( idImovelSelect !== imovel.id )
-            if( imovel.fl_inspection )
+            if( loadingStatusVistoria || imovel.fl_inspection )
               return;
           
           props.handleImovel( imovel );

--- a/src/services/requests/Vistoria.js
+++ b/src/services/requests/Vistoria.js
@@ -20,3 +20,10 @@ export const getInspectsByTeam = data => {
     ...headerAuthorization()
   });
 }
+
+export const getNewInspectStatus = data => {
+  const { trabalho_diario_id, imovel_id } = data;
+  return api.get(`/vistorias/status/${ trabalho_diario_id }/trabalhos_diarios/${ imovel_id }/imoveis`, {
+    ...headerAuthorization()
+  });
+}

--- a/src/store/Vistoria/vistoriaActions.js
+++ b/src/store/Vistoria/vistoriaActions.js
@@ -13,7 +13,12 @@ export const ActionTypes = {
   SET_RECIPIENT: "SET_RECIPIENT",
   SET_SEQUENCE_INSPECTION: "SET_SEQUENCE_INSPECTION",
   SET_IMMOBILE: "SET_IMMOBILE",
-  GET_INSPECTS_BY_DAILY_WORK_REQUEST: "GET_INSPECTS_BY_DAILY_WORK_REQUEST"
+  GET_INSPECTS_BY_DAILY_WORK_REQUEST: "GET_INSPECTS_BY_DAILY_WORK_REQUEST",
+  GET_NEW_INSPECT_STATUS_REQUEST: "GET_NEW_INSPECT_STATUS_REQUEST",
+  GET_NEW_INSPECT_STATUS_SUCCESS: "GET_NEW_INSPECT_STATUS_SUCCESS",
+  GET_NEW_INSPECT_STATUS_FAIL: "GET_NEW_INSPECT_STATUS_FAIL",
+  NEW_INSPECT_STATUS_RESET: "NEW_INSPECT_STATUS_RESET",
+  LIMPAR_STATUS_NOVA_VISTORIA: "LIMPAR_STATUS_NOVA_VISTORIA"
 }
 
 export const setImovel = imovel => {
@@ -159,5 +164,42 @@ export const getInspectsByDailyWork = vistorias => {
     payload: {
       vistorias
     }
+  }
+}
+
+export const getNewInspectStatusRequest = (trabalho_diario_id, imovel_id) => {
+  return {
+    type: ActionTypes.GET_NEW_INSPECT_STATUS_REQUEST,
+    payload: {
+      trabalho_diario_id,
+      imovel_id
+    }
+  }
+}
+
+export const getNewInspectStatusSuccess = (statusNovaVistoria) => {
+  return {
+    type: ActionTypes.GET_NEW_INSPECT_STATUS_SUCCESS,
+    payload: {
+      statusNovaVistoria
+    }
+  }
+}
+
+export const getNewInspectStatusFail = () => {
+  return {
+    type: ActionTypes.GET_NEW_INSPECT_STATUS_FAIL,
+  }
+}
+
+export const newInspectStatusReset = () => {
+  return {
+    type: ActionTypes.NEW_INSPECT_STATUS_RESET,
+  }
+}
+
+export const limparStatusNovaVistoria = () => {
+  return {
+    type: ActionTypes.LIMPAR_STATUS_NOVA_VISTORIA
   }
 }

--- a/src/store/Vistoria/vistoriaReduce.js
+++ b/src/store/Vistoria/vistoriaReduce.js
@@ -25,7 +25,9 @@ const INITIAL_STATE = {
   reload: false,
   updatedIndex: -1,
   duplicatorIndex: -1,
-  vistorias: []
+  vistorias: [],
+  statusNovaVistoria:"",
+  buscaStatusNovaVistoria:null
 }
 
 export default function Vistoria(state = INITIAL_STATE, action) {
@@ -157,6 +159,37 @@ export default function Vistoria(state = INITIAL_STATE, action) {
         ...state,
         recipientes: [ ...state.recipientes, ...recips ],
         sequenciaRecipiente: seq
+      }
+    }
+
+    case ActionTypes.GET_NEW_INSPECT_STATUS_SUCCESS: {
+      let statusNovaVistoria = action.payload.statusNovaVistoria;
+
+      return {
+        ...state,
+        statusNovaVistoria,
+        buscaStatusNovaVistoria:true
+      }
+    }
+
+    case ActionTypes.GET_NEW_INSPECT_STATUS_FAIL: {
+      return {
+        ...state,
+        buscaStatusNovaVistoria:false
+      }
+    }
+
+    case ActionTypes.NEW_INSPECT_STATUS_RESET: {
+      return {
+        ...state,
+        buscaStatusNovaVistoria:null
+      }
+    }
+
+    case ActionTypes.LIMPAR_STATUS_NOVA_VISTORIA: {
+      return {
+        ...state,
+        statusNovaVistoria:""
       }
     }
 

--- a/src/store/Vistoria/vistoriaSagas.js
+++ b/src/store/Vistoria/vistoriaSagas.js
@@ -47,6 +47,29 @@ export function* getInspectsByDailyWork( action ) {
   }
 }
 
+export function* getNewInspectStatus( action ) {
+  try {
+    const { data, status } = yield call( servico.getNewInspectStatus, action.payload );
+
+    if( status === 200 ) {
+      yield put( VistoriaActions.getNewInspectStatusSuccess( data.statusNovaVistoria ) );
+    }else {
+      yield put( AppConfigActions.showNotifyToast( "Falha ao definir status da nova vistoria: " + status, "error" ) );
+    }
+
+  } catch (err) {
+    yield put( VistoriaActions.getNewInspectStatusFail() );
+    if(err.response){
+      //Provavel erro de logica na API
+      yield put( AppConfigActions.showNotifyToast( "Erro ao definir status da nova vistoria, entre em contato com o suporte", "error" ) );
+      
+    }
+    //Se chegou aqui, significa que não houve resposta da API
+    else
+      yield put( AppConfigActions.showNotifyToast( "Erro ao definir status da nova vistoria, favor verifique a conexão", "error" ) );
+  }
+}
+
 function* watchGetInspects() {
   yield takeLatest( VistoriaActions.ActionTypes.CONSULTAR_VISTORIAS_REQUEST, getInspects );
 }
@@ -55,9 +78,14 @@ function* watchGetInspectsByDailyWork() {
   yield takeLatest( VistoriaActions.ActionTypes.GET_INSPECTS_BY_DAILY_WORK_REQUEST, getInspectsByDailyWork );
 }
 
+function* watchGetNewInspectStatus() {
+  yield takeLatest( VistoriaActions.ActionTypes.GET_NEW_INSPECT_STATUS_REQUEST, getNewInspectStatus );
+}
+
 export function* vistoriaSaga() {
   yield all( [
     watchGetInspects(),
     watchGetInspectsByDailyWork(),
+    watchGetNewInspectStatus()
   ] );
 }


### PR DESCRIPTION
Antes deste commit, o próprio usuário tinha que definir o status de vistoria (normal ou recuperada), o que podia causar erro humano

Digamos que um agente semana passada não conseguiu realizar a vistoria no imovel x por ele estar fechada, logo cadastra no sistema um vistoria normal e com pendencia fechada.

Agora hoje, outro agente vai fazer a vistoria neste mesmo imovel x, logo é um vistoria recuperada, no entanto este agente não sabe que este imovel já foi visitado antes e poderia colocar a vistoria como normal.

Com este commit, a própria plataforma web define qual o status da visita da vistoria, evitando o possível erro humano