### PR TITLE
Alteracao rotas20

### DIFF
--- a/src/controllers/TrabalhoDiarioController.js
+++ b/src/controllers/TrabalhoDiarioController.js
@@ -38,6 +38,7 @@ getByUser = async ( req, res ) => {
       where: {
         usuario_id
       },
+      order: [[ 'data', 'desc' ]],
       include: [
         {
           association: 'supervisor',
@@ -213,6 +214,7 @@ getByTeamAndUser = async ( req, res ) => {
         usuario_id,
         equipe_id
       },
+      order: [[ 'data', 'desc' ]],
       include: [
         {
           association: 'supervisor',


### PR DESCRIPTION
Com este commit, o próprio back-end determina o status de visita de um imovel em uma nova vistoria, se é normal ou recuperada

Para a aplicação mobile, a própria função getAllRoutes do RotasController já define os status de visita de cada imovel na rota. Embora isso deixe a função mais lenta, o status da vistoria de cada imovel deve ser definido enquanto é garantido ter sinal de internet, que é justamente quando a rota está sendo iniciada

Já na plataforma web foi feito outra abordagem, já que a internet sempre está disponível em um computador. Foi criado uma nova rota na VistoriaController chamado getNewInspectStatus. Quando o usuario esta criando uma nova vistoria na plataforma web, ele deve selecionar o imovel, quando isso ocorrer é chamado no back-end a função getNewInspectStatus, que é responsável por definir o status da vistoria no imovel selecionado( normal ou recuperada)

A abordagem diferente na plataforma web se deve porque a rota getAllRoutes é chamado varias vezes durante a realização do trabalho diário, e o processo de automação de status de vistoria faz com que getAllRoutes fique muito lento. Para evitar o sistema web fique devagar, foi optado por fazer a automação do status da vistoria assim que o usuário seleciona o imovel que foi vistoriado.