### PR TITLE
Adição funcionalidades de zona

### DIFF
--- a/src/pages/Quarteiroes/EditarQuarteirao.js
+++ b/src/pages/Quarteiroes/EditarQuarteirao.js
@@ -99,9 +99,9 @@ const EditarQuarteirao = ({ imovel, usuario, quarteirao, ruas, municipio_id, ...
       return ({ value: z.id, label: z.nome })
     });
     const semZona = { value: null, label: "Nenhuma" }
-    if(Object.keys(zona).length === 0)
+    if(!quarteirao.zona)
       setZona(semZona);
-    options.push(semZona)
+    options.unshift(semZona)
     setOptionZona( options );
   }, [ props.zonas ]);
 

--- a/src/pages/Quarteiroes/ModalAdd.js
+++ b/src/pages/Quarteiroes/ModalAdd.js
@@ -37,7 +37,7 @@ function ModalAdd({ municipio_id, created, show, handleClose, ...props }) {
   const [ lados, setLados ]                       = useState( [] );
   const [ localidade, setLocalidade ]             = useState( {} );
   const [ optionLocalidade, setOptionLocalidade ] = useState( [] );
-  const [ zona, setZona ]                         = useState( {} );
+  const [ zona, setZona ]                         = useState( { value: null, label: "Nenhuma" } );
   const [ optionZona, setOptionZona ]             = useState( [] );
   const [ showModalLado, setShowModalLado ]       = useState( false );
   const [ botaoSalvar, setBotaoSalvar ]           = useState( false );
@@ -50,7 +50,7 @@ function ModalAdd({ municipio_id, created, show, handleClose, ...props }) {
     setNumero(null)
     setLados([])
     setLocalidade({})
-    setZona({})
+    setZona({ value: null, label: "Nenhuma" })
     //setOptionZona( [] );
     setShowModalLado(false)
     setFlLoading(false)
@@ -64,7 +64,7 @@ function ModalAdd({ municipio_id, created, show, handleClose, ...props }) {
   useEffect( () => {
     props.setCreated( null );
     props.getLocationByCityRequest( municipio_id );
-    props.getZoneByCityRequest( municipio_id );
+    props.getZoneByCityRequest( municipio_id, 'sim' );
     props.getStreetByCityRequest( municipio_id );
   }, [] );
 
@@ -85,6 +85,8 @@ function ModalAdd({ municipio_id, created, show, handleClose, ...props }) {
   useEffect( () => {
     const options = props.zonas.map( z => ( { value: z.id, label: z.nome } ) );
 
+    const semZona = { value: null, label: "Nenhuma" }
+    options.unshift(semZona)
     setOptionZona( options );
   }, [ props.zonas ] );
 
@@ -135,7 +137,7 @@ function ModalAdd({ municipio_id, created, show, handleClose, ...props }) {
    */
   const clearInput = () => {
     setLocalidade( {} );
-    setZona( {} );
+    setZona( { value: null, label: "Nenhuma" } );
     //setOptionZona( [] );
     setNumero( null );
     setLados( [] );

--- a/src/pages/Zonas/EditarZona.js
+++ b/src/pages/Zonas/EditarZona.js
@@ -3,7 +3,15 @@ import React, { useEffect, useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 import Select from 'react-select';
 import ButtonSave from '../../components/ButtonSave';
+import ButtonNewObject from '../../components/ButtonNewObject';
 import ViewCompactIcon from '@material-ui/icons/ViewCompact';
+import ModalAddBlockInZone from './components/ModalAddBlockInZone';
+import ModalRemoveBlockInZone from './components/ModalRemoveBlockInZone';
+import ModalChangeQuarteiraoInZone from './components/ModalChangeQuarteiraoInZone'
+import { FaBorderAll } from 'react-icons/fa';
+import ButtonClose from '../../components/ButtonClose';
+import ButtonMore from '../../components/ButtonMore';
+import { Lista, ListaItem, ListaIcon } from '../../components/Listas';
 
 // REDUX
 import { bindActionCreators } from 'redux';
@@ -11,26 +19,34 @@ import { connect } from 'react-redux';
 
 // ACTIONS
 import { changeSidebar } from '../../store/Sidebar/sidebarActions';
-import { updateZoneRequest, getZoneByIdRequest, clearUpdate } from '../../store/Zona/zonaActions';
+import { updateZoneRequest, getZoneByIdRequest, clearUpdate, getZoneByCityRequest } from '../../store/Zona/zonaActions';
+import { getQuarteiroesMunicipioSemZonaRequest, setQuarteirao } from '../../store/Quarteirao/quarteiraoActions'
+import { showNotifyToast } from "../../store/AppConfig/appConfigActions";
 
 // STYLES
 import { FormGroup, selectDefault } from '../../styles/global';
 import { ContainerFixed, PageHeader, PageIcon } from '../../styles/util';
 
 // VALIDATIONS FUNCTIONS
-import {isBlank,onlyLetters} from '../../config/function';
+import {isBlank} from '../../config/function';
 
-function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
-  const [ id ]                            = useState(props.match.params.id);
-  const [ nome, setNome ]                 = useState( "" );
-  const [ isValidNome, setIsValidNome ]   = useState( true );
-  const [ ativo, setAtivo ]               = useState({});
-  const [ optionAtivo ]                   = useState([ { value: 1, label: 'Sim' }, { value: 0, label: 'Não' } ]);
-  const [ flLoading, setFlLoading ]       = useState( false );
+function EditarZona({ zona, quarteiroes_zona, getZoneByIdRequest, municipio_id, ...props }) {
+  const [ id ]                                                                = useState(props.match.params.id);
+  const [ nome, setNome ]                                                     = useState( "" );
+  const [ isValidNome, setIsValidNome ]                                       = useState( true );
+  const [ ativo, setAtivo ]                                                   = useState({});
+  const [ optionAtivo ]                                                       = useState([ { value: 1, label: 'Sim' }, { value: 0, label: 'Não' } ]);
+  const [ flLoading, setFlLoading ]                                           = useState( false );
+  const [ showModalQuarteirao, setShowModalQuarteirao]                        = useState(false)
+  const [ showModalRemoverQuarteirao, setShowModalRemoverQuarteirao]          = useState(false)
+  const [ showModalAlteraZonaQuarteierao, setShowModalAlteraZonaQuarteierao]  = useState(false)
+  const [ quarteirao, setQuarteirao]                                          = useState({})
 
   useEffect(() => {
     props.changeSidebar(4, 0);
     getZoneByIdRequest( id );
+    props.getQuarteiroesMunicipioSemZonaRequest( municipio_id );
+    props.getZoneByCityRequest(municipio_id, 'sim')
   }, []);
 
   useEffect(() => {
@@ -56,7 +72,6 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
       setIsValidNome(true)
       setFlLoading(true);
       props.updateZoneRequest( id, {
-        ativo: ativo.value,
         nome: nome
       });
     }
@@ -83,7 +98,6 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
               <Row>
                 <Col sm='6'>
                   <form onSubmit={ handleSubmit } >
-                    <h4 className="title">Informações da localidade</h4>
                     <Row>
                       <Col>
                         <FormGroup>
@@ -92,7 +106,7 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
                             id="up_nome" 
                             value={nome} 
                             className="form-control" 
-                            onChange={ (e) => (onlyLetters(e.target.value) ? setNome(e.target.value) : () => {} )} 
+                            onChange={ (e) => setNome(e.target.value) } 
                             required />
                             {
                               !isValidNome ?
@@ -102,21 +116,6 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
                         </FormGroup>
                       </Col>
                     </Row>
-                    <Row>
-                      <Col>
-                        <FormGroup>
-                          <label htmlFor="categoria">Ativo</label>
-                          <Select
-                            id="ativo"
-                            value={ ativo }
-                            styles={ selectDefault }
-                            options={ optionAtivo }
-                            onChange={ e => setAtivo(e) }
-                            required />
-                        </FormGroup>
-                      </Col>
-                    </Row>
-
                     <ContainerFixed>
                       <ButtonSave
                         title="Salvar"
@@ -128,13 +127,72 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
                   </form>
                 </Col>
 
-                <Col sm='6'>
-                  <h4 className="title">Quarteirões</h4>
+                <Col sm="6">
+                  <h4 className="title">
+                    Quarteirões
+                    <ButtonNewObject
+                      title="Adicionar novo quarteirão na zona"
+                      onClick={ () => setShowModalQuarteirao(true)}
+                    />
+                  </h4>
+                  <Lista>
+                    {quarteiroes_zona.map((q, index) => {
+                      const bg = q.id ? "" : "bg-success"
+                      return (
+                        <ListaItem
+                          key={`lado-${q.id}`}
+                          className={bg +" pt-0 pb-0 justify-content-between"}
+                        >
+                          <div>
+                            <ListaIcon className="mr-2">
+                              <FaBorderAll />
+                            </ListaIcon>
+                            <span className="mr-2">
+                              Nº {q.numero}
+                            </span>
+                          </div>
+                          <div>
+                            <ButtonClose
+                              title="Excluir quarteirao da zona"
+                              onClick={() => {
+                                setQuarteirao(q)
+                                setShowModalRemoverQuarteirao(true)}
+                              }
+                              className="ml-2 text-danger"
+                            />
+                            <ButtonMore
+                              title="Editar zona do quarteirao"
+                              onClick={ () => {
+                                setQuarteirao(q)
+                                setShowModalAlteraZonaQuarteierao(true)
+                              } }
+                            />
+                          </div>
+                        </ListaItem>
+                    )})}
+                  </Lista>
                 </Col>
               </Row>
             </div>
           </article>
         </div>
+        <ModalAddBlockInZone
+          acao={"add"}
+          zona_id={zona.id}
+          show={showModalQuarteirao}
+          handleClose={() => setShowModalQuarteirao(false)}
+          quarteiroes={props.quarteiroes}
+        />
+        <ModalRemoveBlockInZone
+          quarteirao={quarteirao}
+          show={showModalRemoverQuarteirao}
+          handleClose={() => setShowModalRemoverQuarteirao(false)}
+        />
+        <ModalChangeQuarteiraoInZone
+          quarteirao={quarteirao}
+          show={showModalAlteraZonaQuarteierao}
+          handleClose={() => setShowModalAlteraZonaQuarteierao(false)}
+        />
       </section>
     </>
   );
@@ -143,8 +201,10 @@ function EditarZona({ zona, getZoneByIdRequest, municipio_id, ...props }) {
 const mapStateToProps = state => ({
   municipio_id: state.appConfig.usuario.municipio.id,
   zona: state.zona.zona,
+  quarteiroes_zona: state.zona.quarteiroes_zona,
   localidades: state.localidade.localidades,
   updateZone: state.zona.updated,
+  quarteiroes: state.quarteirao.quarteiroes,
 });
 
 const mapDispatchToProps = dispatch =>
@@ -152,7 +212,10 @@ const mapDispatchToProps = dispatch =>
     changeSidebar,
     updateZoneRequest,
     getZoneByIdRequest,
-    clearUpdate
+    getZoneByCityRequest,
+    clearUpdate,
+    getQuarteiroesMunicipioSemZonaRequest,
+    showNotifyToast
   }, dispatch);
 
 export default connect(

--- a/src/pages/Zonas/ModalAdd.js
+++ b/src/pages/Zonas/ModalAdd.js
@@ -4,6 +4,12 @@ import { Row, Col } from 'react-bootstrap';
 import Modal, { ModalBody, ModalFooter } from '../../components/Modal';
 import $ from 'jquery';
 import ButtonSaveModal from '../../components/ButtonSaveModal';
+import { Lista, ListaItem, ListaIcon } from '../../components/Listas';
+import { FaBorderAll } from 'react-icons/fa';
+import ButtonClose from '../../components/ButtonClose';
+import AddBox from '@material-ui/icons/AddBox';
+import { Fab } from '@material-ui/core';
+import ModalQuarteirao from './components/ModalQuarteirao';
 
 // REDUX
 import { bindActionCreators } from 'redux';
@@ -11,38 +17,48 @@ import { connect } from 'react-redux';
 
 // ACTIONS
 import { createZoneRequest, clearCreate } from '../../store/Zona/zonaActions';
+import { getQuarteiroesMunicipioSemZonaRequest } from '../../store/Quarteirao/quarteiraoActions'
+import { showNotifyToast } from '../../store/AppConfig/appConfigActions';
 
 // STYLES
 import { Button } from '../../styles/global';
 import { FormGroup } from '../../styles/global';
 
 // VALIDATIONS FUNCTIONS
-import {isBlank,onlyLetters} from '../../config/function';
+import {isBlank} from '../../config/function';
 
-function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
+function ModalAdd({ show, handleClose, createZoneRequest, created, municipio_id, ...props }) {
 
-  const [ nome, setNome ]                 = useState( "" );
-  const [ isValidNome, setIsValidNome ]   = useState( true );
-  const [ flLoading, setFlLoading ]       = useState( false );
-
-  function handleCadastrar( e ) {
-    e.preventDefault();
-    if(isBlank(nome))
-      setIsValidNome(false)
-    else{
-      setIsValidNome(true)
-      setFlLoading(true)
-      createZoneRequest( municipio_id, nome );
-    }
-  }
+  const [ nome, setNome ]                                  = useState( "" );
+  const [ isValidNome, setIsValidNome ]                    = useState( true );
+  const [ quarteiroes, setQuarteiroes]                     = useState( [] )
+  const [ flLoading, setFlLoading ]                        = useState( false );
+  const [ showModalQuarteirao, setShowModalQuarteirao ]    = useState( false );
 
   useEffect(() => {
     props.clearCreate();
+    props.getQuarteiroesMunicipioSemZonaRequest( municipio_id );
   }, []);
+
+  /**
+   * Acionado sempre que o modal é for aberto
+   * Limpa todos os dados digitado anteriormente
+   * atraves da função limparTudo()
+   */
+  useEffect(() => {
+    if( show ) {
+      clearInput()
+    }
+    //não fecha o modal, mas faz com que o show=false
+    //quando o usuario aperta o botão para abrir o modal novamente
+    //faz com que show=true e então a função limparTudo() é executada
+    handleClose()
+  }, [ show ]);
 
   useEffect(() => {
     setFlLoading(false)
     if( created ){
+      props.getQuarteiroesMunicipioSemZonaRequest( municipio_id );
       closeModal();
     }
     
@@ -58,6 +74,54 @@ function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
   function clearInput() {
     setIsValidNome(true);
     setNome( "" );
+    setQuarteiroes([])
+  }
+
+  const abrirModalQuarteirao = () => {setShowModalQuarteirao( true );}
+
+  /**
+   * Adiciona um novo quarteirao a zona
+   */
+  const addQuarteirao = quarteirao => {
+    setQuarteiroes( [ ...quarteiroes, quarteirao ] );
+    setShowModalQuarteirao( false );
+  }
+
+  /**
+   * Excluir um item do array lados
+   * @param {integer} index
+   */
+  const excluirQuarteirao = index => {
+    let qs = quarteiroes;
+    qs.splice( index, 1 );
+    qs = qs.map( ( q ) => { return q; } );
+    setQuarteiroes( qs );
+  }
+
+  /**
+   * Solicita ao action que adicione um novo quarteirão
+   * @param {element} e elemento que acionou a função
+   */
+  const handleCadastrar = e => {
+    e.preventDefault();
+
+    var isValido = true
+    if(isBlank(nome)){
+      setIsValidNome(false)
+      isValido = false
+    }
+    else if(quarteiroes.length == 0){
+      setIsValidNome(true)
+      isValido = false
+      props.showNotifyToast("Por favor adicione ao menos 1 quarteirao na zona",'warning')
+    }
+
+    if (isValido) {
+      setIsValidNome(true)
+      const quarteiroes_id = quarteiroes.map( q => q.id)
+      setFlLoading(true)
+      createZoneRequest( municipio_id, nome, quarteiroes_id );
+    }
   }
 
   return(
@@ -75,7 +139,7 @@ function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
                   id="nome" 
                   value={nome} 
                   className ={ `form-control ${ !isValidNome ? 'invalid' : '' }` } 
-                  onChange={ (e) => (onlyLetters(e.target.value) ? setNome(e.target.value) : () => {} )} 
+                  onChange={ (e) => setNome(e.target.value) } 
                   required />
                   {
                     !isValidNome ?
@@ -83,6 +147,50 @@ function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
                       ''
                   }
               </FormGroup>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <FormGroup>
+                <label>
+                  Quarteirões<code>*</code>
+                </label>
+                <Lista>
+                  {quarteiroes.map((q, index) => (
+                    <ListaItem
+                      key={`quart-${index}`}
+                      className="pt-0 pb-0 justify-content-between"
+                    >
+                      <div>
+                        <ListaIcon className="mr-2">
+                          <FaBorderAll />
+                        </ListaIcon>
+                        <span className="mr-2">
+                          Quarteirao nº {q.numero}
+                        </span>
+                      </div>
+
+                      <ButtonClose
+                        title="Excluir quarteirão"
+                        onClick={() => excluirQuarteirao(index)}
+                        className="ml-2 text-danger"
+                      />
+                    </ListaItem>
+                  ))}
+                </Lista>
+              </FormGroup>
+              <Row>
+                <Col className="text-right">
+                  <Fab
+                    className="bg-success text-white"
+                    size="medium"
+                    aria-label="Cadastrar um novo lado"
+                    onClick={() => abrirModalQuarteirao()}
+                  >
+                    <AddBox />
+                  </Fab>
+                </Col>
+              </Row>
             </Col>
           </Row>
         </ModalBody>
@@ -98,17 +206,25 @@ function ModalAdd({ createZoneRequest, created, municipio_id, ...props }) {
           <ButtonSaveModal title="Salvar" loading={ flLoading } disabled={ flLoading } type="submit" />
         </ModalFooter>
       </form>
+      <ModalQuarteirao
+        acao={"add"} // add ou editar
+        show={showModalQuarteirao}
+        handleClose={() => setShowModalQuarteirao(false)}
+        quarteiroes={props.quarteiroes}
+        addQuarteirao={addQuarteirao}
+      />
     </Modal>
   );
 }
 
 const mapStateToProps = state => ({
   municipio_id: state.appConfig.usuario.municipio.id,
+  quarteiroes: state.quarteirao.quarteiroes,
   created: state.zona.created
  });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ createZoneRequest, clearCreate }, dispatch);
+  bindActionCreators({ createZoneRequest, clearCreate, getQuarteiroesMunicipioSemZonaRequest,showNotifyToast }, dispatch);
 
 export default connect(
   mapStateToProps,

--- a/src/pages/Zonas/ModalDisabled.js
+++ b/src/pages/Zonas/ModalDisabled.js
@@ -1,20 +1,25 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import Modal, { ModalBody, ModalFooter } from '../../components/Modal';
 import $ from 'jquery';
+import LoadginGif from '../../assets/loading.gif';
+
 
 // REDUX
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 // ACTIONS
-import { updateZoneRequest, clearUpdate } from '../../store/Zona/zonaActions';
+import { updateZoneRequest, clearUpdate, getZoneByCityRequest } from '../../store/Zona/zonaActions';
 
 // STYLES
 import { Button } from '../../styles/global';
 
 function ModalDisabled( props ) {
+  const [ flLoading, setFlLoading ] = useState( false );
+
   function handleClick() {
+    setFlLoading( true );
     props.tableSelected.forEach( row => {
       const { id } = props.zonas[ row.dataIndex ];
 
@@ -30,18 +35,46 @@ function ModalDisabled( props ) {
 
   useEffect(() => {
     if( props.updated ) {
+      props.getZoneByCityRequest( props.municipio_id, 'sim' );
+      setFlLoading( false );
       $('#modal-desativar-zona').modal('hide');
     }
   }, [ props.updated ]);
 
   return(
-    <Modal id="modal-desativar-zona" title="Desativar Zona(s)" centered={ true }>
+    <Modal id="modal-desativar-zona" title="Excluir Zona(s)" centered={ true }>
       <ModalBody>
-        <p>Deseja desativar a(s) zona(s)?</p>
+        <p>Deseja mesmo excluir a(s) zona(s)?</p>
       </ModalBody>
       <ModalFooter>
-        <Button className="secondary" data-dismiss="modal">Cancelar</Button>
-        <Button className="danger" onClick={ handleClick }>Confirmar</Button>
+        <Button 
+          className="secondary" 
+          data-dismiss="modal" 
+          disabled={ flLoading }>
+            Cancelar
+        </Button>
+        <Button
+          className="danger"
+          onClick={ handleClick }
+          loading={ flLoading.toString() }
+          disabled={ flLoading ? 'disabled' : '' }
+        >
+          {
+            flLoading ?
+              (
+                <>
+                  <img
+                    src={ LoadginGif }
+                    width="25"
+                    style={{ marginRight: 10 }}
+                    alt="Carregando"
+                  />
+                  Excluindo...
+                </>
+              ) :
+              "Confirmar"
+          }
+        </Button>
       </ModalFooter>
     </Modal>
   );
@@ -50,11 +83,12 @@ function ModalDisabled( props ) {
 const mapStateToProps = state => ({
   tableSelected: state.supportInfo.tableSelection.tableZone,
   zonas: state.zona.zonas,
-  updated: state.zona.updated
+  updated: state.zona.updated,
+  municipio_id: state.appConfig.usuario.municipio.id,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ updateZoneRequest, clearUpdate }, dispatch);
+  bindActionCreators({ updateZoneRequest, clearUpdate, getZoneByCityRequest }, dispatch);
 
 export default connect(
   mapStateToProps,

--- a/src/pages/Zonas/components/ModalAddBlockInZone.js
+++ b/src/pages/Zonas/components/ModalAddBlockInZone.js
@@ -1,0 +1,162 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import { Row, Col, Modal } from 'react-bootstrap';
+import SelectWrap from '../../../components/SelectWrap';
+import ButtonSaveModal from '../../../components/ButtonSaveModal';
+
+// REDUX
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+// ACTIONS
+import { getZoneByIdRequest } from '../../../store/Zona/zonaActions';
+import { 
+  inserirQuarteiraoEmZonaRequest, 
+  inserirQuarteiraoEmZonaReset,
+  getQuarteiroesMunicipioSemZonaRequest
+} from '../../../store/Quarteirao/quarteiraoActions';
+
+import { showNotifyToast } from "../../../store/AppConfig/appConfigActions";
+// STYLES
+import { ContainerArrow } from '../../../styles/util';
+import { Button, FormGroup, selectDefault } from '../../../styles/global';
+
+
+const ModalAddBlockInZone = ( { zona_id, acao, show, handleClose, quarteiroes, ...props } ) => {
+  const [ quarteirao, setQuarteirao ]                             = useState( {} );
+  const [ optionQuarteirao, setOptionQuarteirao ]   = useState( [] );
+  const [ flLoading, setFlLoading ]                 = useState( false );
+
+   /**
+   *  Limpa os campos toda vez que o modal for aberto
+   */
+  useEffect(() => {
+    if( show ) {
+      limparTudo()
+    }
+  }, [ show ]);
+
+  /**
+   * Preenchendo as opções do select de quarteirao
+   */
+  useEffect(() => {
+    const options = quarteiroes.map( q => ( { value: q.id, label: q.numero } ) );
+
+    setOptionQuarteirao( options );
+  }, [ quarteiroes ]);
+
+
+
+  useEffect(() => {
+    if(props.insertedZone){
+      props.getZoneByIdRequest( zona_id ); // atualizando lista de quarteirões da zona
+      props.getQuarteiroesMunicipioSemZonaRequest( props.municipio_id ); //atualizando lista de quarteirões que podem ser adicionados
+      
+      setTimeout(() => { 
+        setFlLoading(false)
+        props.inserirQuarteiraoEmZonaReset()
+        props.showNotifyToast( "Quarteirão inserido com sucesso", "success" )
+        handleClose()
+        //document.location.reload( true );
+      }, 3000)
+    }else{
+      setFlLoading(false)
+      props.inserirQuarteiraoEmZonaReset()
+    }
+  }, [ props.insertedZone ]);
+
+
+
+  /**
+   * Esta função chama a action para adicionar um imóvel ao quarteirão.
+   * 
+   * @param {object} e Elemento que acionou esaa função
+   */
+  const handleSubmit = e => {
+    e.preventDefault();
+    setFlLoading(true)
+    props.inserirQuarteiraoEmZonaRequest(quarteirao.value, zona_id)
+  }
+
+  function limparTudo(){
+    setQuarteirao( {} );
+    setFlLoading( false );
+    props.inserirQuarteiraoEmZonaReset()
+  }
+
+  return(
+    <Modal show={ show } onHide={ handleClose } backdrop="static" keyboard={false}>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          { acao == 'add' ? 'Adicionar' : 'Editar' } Quarteirão
+        </Modal.Title>
+      </Modal.Header>
+      <form onSubmit={ handleSubmit }>
+        <Modal.Body>
+          <p className="text-description">
+            <b>OBS1:</b> Os campos com <code>*</code> são obrigatórios
+          </p>
+          <Row>
+            <Col md="12">
+              <FormGroup>
+                <label htmlFor="l_rua">Nº do quarteirão  <code>*</code></label>
+                <SelectWrap
+                  id="l_rua"
+                  value={ quarteirao }
+                  styles={ selectDefault }
+                  options={ optionQuarteirao }
+                  onChange={ e => setQuarteirao( e ) }
+                  required
+                />
+              </FormGroup>
+            </Col>
+          </Row>
+        </Modal.Body>
+        <Modal.Footer>
+          <ContainerArrow className="justify-content-end">
+            <div>
+            <Button 
+                type="button" 
+                className="secondary" 
+                data-dismiss="modal" 
+                onClick={ handleClose }
+                disabled={ flLoading }>
+                  Cancelar
+              </Button>
+              <ButtonSaveModal title="Salvar" loading={ flLoading } disabled={ flLoading } type="submit" />
+            </div>
+          </ContainerArrow>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}
+
+/**
+ * Mapeia o estado global da aplicação a propriedade do componente
+ * @param {Object} state estado global
+ * @returns 
+ */
+const mapStateToProps = state => ( {
+  municipio_id: state.appConfig.usuario.municipio.id,
+  insertedZone: state.quarteirao.insertedZone,
+} );
+
+/**
+ * Mapeia ações a propriedade do componente
+ * @param {*} dispatch 
+ * @returns 
+ */
+const mapDispatchToProps = dispatch =>
+  bindActionCreators( {
+    inserirQuarteiraoEmZonaRequest,
+    inserirQuarteiraoEmZonaReset,
+    getQuarteiroesMunicipioSemZonaRequest,
+    getZoneByIdRequest,
+    showNotifyToast
+  }, dispatch );
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)( ModalAddBlockInZone );

--- a/src/pages/Zonas/components/ModalChangeQuarteiraoInZone.js
+++ b/src/pages/Zonas/components/ModalChangeQuarteiraoInZone.js
@@ -1,0 +1,161 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import { Row, Col, Modal } from 'react-bootstrap';
+import SelectWrap from '../../../components/SelectWrap';
+import ButtonSaveModal from '../../../components/ButtonSaveModal';
+
+// REDUX
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+// ACTIONS
+import { getZoneByIdRequest } from '../../../store/Zona/zonaActions';
+import { 
+    inserirQuarteiraoEmZonaRequest, 
+    inserirQuarteiraoEmZonaReset,
+    getQuarteiroesMunicipioSemZonaRequest
+ } from '../../../store/Quarteirao/quarteiraoActions';
+import { showNotifyToast } from "../../../store/AppConfig/appConfigActions";
+
+// STYLES
+import { ContainerArrow } from '../../../styles/util';
+import { Button, FormGroup, selectDefault } from '../../../styles/global';
+
+
+const ModalChangeQuarteiraoInZone = ( {quarteirao, show, handleClose, ...props } ) => {
+ 
+  const zona_original = { value: props.zona.id, label: props.zona.nome }
+
+  const [ zona, setZona ]               = useState( zona_original );
+  const [ optionZona, setOptionZona ]   = useState( [] );
+  const [ flLoading, setFlLoading ]     = useState( false );
+
+   /**
+   *  Limpa os campos toda vez que o modal for aberto
+   */
+  useEffect(() => {
+    if( show ) {
+      limparTudo()
+    }
+  }, [ show ]);
+
+  /**
+   * Preenchendo as opções do select de quarteirao
+   */
+  useEffect(() => {
+    const options = props.zonas.map( z => ( { value: z.id, label: z.nome } ) );
+    setOptionZona( options );
+  }, [ props.zonas ]);
+
+
+  useEffect(() => {
+    if(props.updatedZone){
+      props.getZoneByIdRequest( props.zona.id ); // atualizando lista de quarteirões da zona
+      props.getQuarteiroesMunicipioSemZonaRequest( props.municipio_id ); //atualizando lista de quarteirões que podem ser adicionados
+      
+      setTimeout(() => { 
+        setFlLoading(false)
+        props.inserirQuarteiraoEmZonaReset()
+        props.showNotifyToast( "Zona do quarteirão alterada com sucesso", "success" )
+        handleClose()
+        //document.location.reload( true );
+      }, 3000)
+    }else{
+      setFlLoading(false)
+      props.inserirQuarteiraoEmZonaReset()
+    }
+  }, [ props.updatedZone ]);
+
+  /**
+   * Esta função chama a action para adicionar um imóvel ao quarteirão.
+   * 
+   * @param {object} e Elemento que acionou esaa função
+   */
+  const handleSubmit = e => {
+    e.preventDefault();
+    setFlLoading(true)
+    props.inserirQuarteiraoEmZonaRequest(quarteirao.id, zona.value, true)
+  }
+
+  function limparTudo(){
+    setZona( zona_original );
+  }
+
+  return(
+    <Modal show={ show } onHide={ handleClose } backdrop="static" keyboard={false}>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          Editar zona do quarteirão
+        </Modal.Title>
+      </Modal.Header>
+      <form onSubmit={ handleSubmit }>
+        <Modal.Body>
+          <p className="text-description">
+            <b>OBS1:</b> Os campos com <code>*</code> são obrigatórios
+          </p>
+          <Row>
+            <Col md="12">
+              <FormGroup>
+                <label htmlFor="l_zona">Zona <code>*</code></label>
+                <SelectWrap
+                  id="l_zona"
+                  value={ zona }
+                  styles={ selectDefault }
+                  options={ optionZona }
+                  onChange={ e => setZona( e ) }
+                  required
+                />
+              </FormGroup>
+            </Col>
+          </Row>
+        </Modal.Body>
+        <Modal.Footer>
+          <ContainerArrow className="justify-content-end">
+            <div>
+            <Button 
+                type="button" 
+                className="secondary" 
+                data-dismiss="modal" 
+                onClick={ handleClose }
+                disabled={ flLoading }>
+                  Cancelar
+              </Button>
+              <ButtonSaveModal title="Salvar" loading={ flLoading } disabled={ flLoading } type="submit" />
+            </div>
+          </ContainerArrow>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}
+
+/**
+ * Mapeia o estado global da aplicação a propriedade do componente
+ * @param {Object} state estado global
+ * @returns 
+ */
+const mapStateToProps = state => ( {
+  zona: state.zona.zona,
+  zonas: state.zona.zonas,
+  municipio_id: state.appConfig.usuario.municipio.id,
+  updatedZone: state.quarteirao.updatedZone,
+} );
+
+/**
+ * Mapeia ações a propriedade do componente
+ * @param {*} dispatch 
+ * @returns 
+ */
+const mapDispatchToProps = dispatch =>
+  bindActionCreators( {
+    inserirQuarteiraoEmZonaRequest,
+    inserirQuarteiraoEmZonaReset,
+    getZoneByIdRequest,
+    getQuarteiroesMunicipioSemZonaRequest,
+    showNotifyToast
+  }, dispatch );
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)( ModalChangeQuarteiraoInZone );

--- a/src/pages/Zonas/components/ModalQuarteirao.js
+++ b/src/pages/Zonas/components/ModalQuarteirao.js
@@ -1,0 +1,140 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import { Row, Col, Modal } from 'react-bootstrap';
+import SelectWrap from '../../../components/SelectWrap';
+import ButtonSaveModal from '../../../components/ButtonSaveModal';
+
+// REDUX
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+// ACTIONS
+import { getRuaPorCepRequest, streetExistRequest, clearStreetExist } from '../../../store/Rua/ruaActions';
+
+// STYLES
+import { ContainerArrow } from '../../../styles/util';
+import { Button, FormGroup, selectDefault } from '../../../styles/global';
+
+/**
+ * Modal de adição de quarteirao à uma zona
+ * @param {String} acao cadastrar ou editar
+ * @param {Boolean} show abrir ou fechar modal
+ * @param {Function} handleClose função para fechar modal
+ * @param {Function} addQuarteirao função para adicionar quarteirao
+ * @param {Object} props demais propriedades para funcionamento do componente
+ * @returns 
+ */
+const ModalQuarteirao = ( { acao, show, handleClose, quarteiroes, addQuarteirao, ...props } ) => {
+  const [ quarteirao, setQuarteirao ]                             = useState( {} );
+  const [ optionQuarteirao, setOptionQuarteirao ]   = useState( [] );
+  const [ flLoading, setFlLoading ]                 = useState( false );
+
+   /**
+   *  Limpa os campos toda vez que o modal for aberto
+   */
+  useEffect(() => {
+    if( show ) {
+      limparTudo()
+    }
+  }, [ show ]);
+
+  /**
+   * Preenchendo as opções do select de quarteirao
+   */
+  useEffect(() => {
+    const options = quarteiroes.map( q => ( { value: q.id, label: q.numero } ) );
+
+    setOptionQuarteirao( options );
+  }, [ quarteiroes ]);
+
+
+  /**
+   * Esta função chama a action para adicionar um imóvel ao quarteirão.
+   * 
+   * @param {object} e Elemento que acionou esaa função
+   */
+  const handleSubmit = e => {
+    e.preventDefault();
+    const quart = {id: quarteirao.value, numero: quarteirao.label} 
+    addQuarteirao( quart );
+    
+  }
+
+  function limparTudo(){
+    setQuarteirao( {} );
+  }
+
+  return(
+    <Modal show={ show } onHide={ handleClose } backdrop="static" keyboard={false}>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          { acao == 'add' ? 'Adicionar' : 'Editar' } Quarteirão
+        </Modal.Title>
+      </Modal.Header>
+      <form onSubmit={ handleSubmit }>
+        <Modal.Body>
+          <p className="text-description">
+            <b>OBS1:</b> Os campos com <code>*</code> são obrigatórios
+          </p>
+          <Row>
+            <Col md="12">
+              <FormGroup>
+                <label htmlFor="l_rua">Nº do quarteirão  <code>*</code></label>
+                <SelectWrap
+                  id="l_rua"
+                  value={ quarteirao }
+                  styles={ selectDefault }
+                  options={ optionQuarteirao }
+                  onChange={ e => setQuarteirao( e ) }
+                  required
+                />
+              </FormGroup>
+            </Col>
+          </Row>
+          <div style={{height:200}}></div>
+        </Modal.Body>
+        <Modal.Footer>
+          <ContainerArrow className="justify-content-end">
+            <div>
+            <Button 
+                type="button" 
+                className="secondary" 
+                data-dismiss="modal" 
+                onClick={ handleClose }
+                disabled={ flLoading }>
+                  Cancelar
+              </Button>
+              <ButtonSaveModal title="Salvar" loading={ flLoading } disabled={ flLoading } type="submit" />
+            </div>
+          </ContainerArrow>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}
+
+/**
+ * Mapeia o estado global da aplicação a propriedade do componente
+ * @param {Object} state estado global
+ * @returns 
+ */
+const mapStateToProps = state => ( {
+  municipio_id: state.appConfig.usuario.municipio.id,
+} );
+
+/**
+ * Mapeia ações a propriedade do componente
+ * @param {*} dispatch 
+ * @returns 
+ */
+const mapDispatchToProps = dispatch =>
+  bindActionCreators( {
+    getRuaPorCepRequest,
+    streetExistRequest,
+    clearStreetExist,
+  }, dispatch );
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)( ModalQuarteirao );

--- a/src/pages/Zonas/components/ModalRemoveBlockInZone.js
+++ b/src/pages/Zonas/components/ModalRemoveBlockInZone.js
@@ -1,0 +1,113 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import { ModalBody, ModalFooter } from '../../../components/Modal';
+import { Modal } from 'react-bootstrap';
+import $ from 'jquery';
+import LoadginGif from '../../../assets/loading.gif';
+
+
+// REDUX
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+// ACTIONS
+import { getZoneByIdRequest } from '../../../store/Zona/zonaActions';
+import { 
+    removerQuarteiraoEmZonaRequest, 
+    removerQuarteiraoEmZonaReset,
+    getQuarteiroesMunicipioSemZonaRequest
+} from '../../../store/Quarteirao/quarteiraoActions';
+import { showNotifyToast } from "../../../store/AppConfig/appConfigActions";
+// STYLES
+import { Button } from '../../../styles/global';
+
+const ModalRemoveBlockInZone = ( {quarteirao, show, handleClose, ...props} ) => {
+  const [ flLoading, setFlLoading ] = useState( false );
+
+  function handleClick() {
+    setFlLoading( true );
+    props.removerQuarteiraoEmZonaRequest(quarteirao.id)
+  }
+
+  useEffect(() => {
+    if( props.removedZone ) {
+        props.getZoneByIdRequest( props.zona.id ); // atualizando lista de quarteirões da zona
+        props.getQuarteiroesMunicipioSemZonaRequest( props.municipio_id ); //atualizando lista de quarteirões que podem ser adicionados
+
+        setTimeout(() => { 
+            setFlLoading(false)
+            props.removerQuarteiraoEmZonaReset()
+            props.showNotifyToast( "Quarteirão removido com sucesso", "success" )
+            handleClose()
+            //document.location.reload( true );
+        }, 3000)
+    }
+    else{
+        setFlLoading(false)
+        props.removerQuarteiraoEmZonaReset()
+    }
+  }, [ props.removedZone ]);
+
+  return(
+    <Modal show={ show } onHide={ handleClose } backdrop="static" keyboard={false} centered={ true }>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          Remover quarteirão da zona
+        </Modal.Title>
+      </Modal.Header>
+      <ModalBody>
+        <p>Deseja mesmo remover o quarteirão de nº {quarteirao.numero} dessa zona?</p>
+      </ModalBody>
+      <ModalFooter>
+        <Button 
+          className="secondary" 
+          data-dismiss="modal" 
+          disabled={ flLoading }>
+            Cancelar
+        </Button>
+        <Button
+          className="danger"
+          onClick={ handleClick }
+          loading={ flLoading.toString() }
+          disabled={ flLoading ? 'disabled' : '' }
+        >
+          {
+            flLoading ?
+              (
+                <>
+                  <img
+                    src={ LoadginGif }
+                    width="25"
+                    style={{ marginRight: 10 }}
+                    alt="Carregando"
+                  />
+                  Removendo...
+                </>
+              ) :
+              "Confirmar"
+          }
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+const mapStateToProps = state => ({
+  municipio_id: state.appConfig.usuario.municipio.id,
+  zona: state.zona.zona,
+  removedZone: state.quarteirao.removedZone,
+});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ 
+    removerQuarteiraoEmZonaRequest, 
+    removerQuarteiraoEmZonaReset,
+    getQuarteiroesMunicipioSemZonaRequest,
+    getZoneByIdRequest,
+    showNotifyToast 
+}, dispatch);
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ModalRemoveBlockInZone);

--- a/src/pages/Zonas/index.js
+++ b/src/pages/Zonas/index.js
@@ -6,6 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import ModalAdd from "./ModalAdd";
 import ModalDisabled from "./ModalDisabled";
 import ViewCompactIcon from '@material-ui/icons/ViewCompact';
+import $ from "jquery";
 
 // REDUX
 import { bindActionCreators } from 'redux';
@@ -56,11 +57,11 @@ const columns = [
   },
   "Cod. Município",
   "Município",
-  "Ativo"
 ];
 
 function Zonas({ zonas, municipio, ...props }) {
   const [ rows, setRows ] = useState([]);
+  const [ showModalAdd, setShowModalAdd] = useState(false)
 
   const options = {
     customToolbar: () => {
@@ -68,14 +69,18 @@ function Zonas({ zonas, municipio, ...props }) {
         <ButtonAdd
           title="Adicionar"
           data-toggle="modal"
-          data-target="#modal-novo-zona" />
+          data-target="#modal-novo-zona" 
+          onClick={() => {setShowModalAdd(true)}} />
       );
     },
     customToolbarSelect: ({ data }) => {
       props.changeTableSelected('tableZone', data);
       return (
         <ButtonDesabled
-          title="Deletar zona(s)"
+          onClick={() => {
+            $("#modal-desativar-zona").modal("show");
+          }}
+          title="Excluir zona(s)"
           toggle="modal"
           target="#modal-desativar-zona" />
       );
@@ -96,7 +101,7 @@ function Zonas({ zonas, municipio, ...props }) {
 
   useEffect(() => {
     props.changeSidebar(4, 1);
-    props.getZoneByCityRequest( municipio.id );
+    props.getZoneByCityRequest( municipio.id, 'sim' );
   }, []);
 
   useEffect(() => {
@@ -112,7 +117,6 @@ function Zonas({ zonas, municipio, ...props }) {
         getDateBr( z.updatedAt ),
         municipio.codigo,
         municipio.nome,
-        z.ativo ? "Sim" : "Não"
       ])
     });
 
@@ -141,7 +145,7 @@ function Zonas({ zonas, municipio, ...props }) {
           </article>
         </div>
 
-        <ModalAdd />
+        <ModalAdd show={showModalAdd} handleClose={() => { setShowModalAdd(false) }} />
         <ModalDisabled />
       </section>
     </>

--- a/src/services/requests/Quarteirao.js
+++ b/src/services/requests/Quarteirao.js
@@ -13,6 +13,13 @@ export const getQuarteiroesPorMunicipioRequest = data => {
   } );
 }
 
+export const getQuarteiroesPorMunicipioSemZonaRequest = data => {
+  const { municipio_id } = data;
+  return api.get( `/quarteiroes/semZona/${ municipio_id }/municipios`, {
+    ...headerAuthorization()
+  } );
+}
+
 /**
  * Solicita a API add um quarteirão
  * @param {Object} data 
@@ -87,4 +94,19 @@ export const getQuarteiraoPorIdRequest = data => {
   return api.get(`/quarteiroes/${ id }`, {
     ...headerAuthorization()
   });
+}
+
+
+export const inserirQuarteiraoEmZona = data => {
+  const { id, zona_id } = data;
+  return api.put( `/quarteiroes/${ id }/zona/${ zona_id }`, {}, {
+    ...headerAuthorization()
+  } );
+}
+
+export const removerQuarteiraoEmZona = data => {
+  const { id } = data;
+  return api.put( `/quarteiroes/${ id }/removerDaZona`, {}, {
+    ...headerAuthorization()
+  } );
 }

--- a/src/services/requests/Zona.js
+++ b/src/services/requests/Zona.js
@@ -1,7 +1,12 @@
 import api, { headerAuthorization } from '../../services/api';
 
-export const getZoneByCityRequest = municipio_id => {
-  return api.get(`/zonas/${ municipio_id }/municipios`, {
+export const getZoneByCityRequest = data => {
+  const { municipio_id, ativo } = data;
+  var url = `/zonas/${ municipio_id }/municipios`
+  if(ativo != null)
+    url = url + `?ativo=${ativo}`
+  
+  return api.get(url, {
     ...headerAuthorization()
   });
 }
@@ -14,11 +19,12 @@ export const getZoneByLocalityRequest = data => {
 }
 
 export const createZoneRequest = data => {
-  const { municipio_id, nome } = data;
+  const { municipio_id, nome, quarteiroes_id } = data;
 
   return api.post(`/zonas`, {
     municipio_id,
-    nome
+    nome,
+    quarteiroes_id
   },
   {
     ...headerAuthorization()

--- a/src/store/Quarteirao/quarteiraoActions.js
+++ b/src/store/Quarteirao/quarteiraoActions.js
@@ -1,21 +1,30 @@
 export const ActionTypes = {
-  GET_QUARTEIROES_MUNICIPIO_REQUEST     : "GET_QUARTEIROES_MUNICIPIO_REQUEST",
-  SET_QUARTEIROES                       : "SET_QUARTEIROES",
-  GET_LADOS_QUARTEIRAO                  : "GET_LADOS_QUARTEIRAO",
-  SET_LADOS                             : "SET_LADOS",
-  SET_IMOVEL_EDITAR                     : "SET_IMOVEL_EDITAR",
-  EDITAR_QUARTEIRAO_REQUEST             : "EDITAR_QUARTEIRAO_REQUEST",
-  SET_UPDATED                           : "SET_UPDATED",
-  SET_CREATED                           : "SET_CREATED",
-  EXCLUIR_LADO_REDUCE                   : "EXCLUIR_LADO_REDUCE",
-  EXCLUIR_LADO_REQUEST                  : "EXCLUIR_LADO_REQUEST",
-  GET_QUARTEIRAO_POR_ID                 : "GET_QUARTEIRAO_POR_ID",
-  SET_QUARTEIRAO                        : "SET_QUARTEIRAO",
-  EXCLUIR_IMOVEL_REQUEST                : "EXCLUIR_IMOVEL_REQUEST",
-  EXCLUIR_IMOVEL_REDUCE                 : "EXCLUIR_IMOVEL_REDUCE",
-  GET_QUARTEIROES_POR_MUNICIPIO_REQUEST : "GET_QUARTEIROES_POR_MUNICIPIO_REQUEST",
-  ADD_QUARTEIRAO_REQUEST                : "ADD_QUARTEIRAO_REQUEST",
-  ADD_QUARTEIRAO_SUCCESS                : "ADD_QUARTEIRAO_SUCCESS",
+  GET_QUARTEIROES_MUNICIPIO_REQUEST           : "GET_QUARTEIROES_MUNICIPIO_REQUEST",
+  GET_QUARTEIROES_MUNICIPIO_SEM_ZONA_REQUEST  : "GET_QUARTEIROES_MUNICIPIO_SEM_ZONA_REQUEST",
+  SET_QUARTEIROES                             : "SET_QUARTEIROES",
+  GET_LADOS_QUARTEIRAO                        : "GET_LADOS_QUARTEIRAO",
+  SET_LADOS                                   : "SET_LADOS",
+  SET_IMOVEL_EDITAR                           : "SET_IMOVEL_EDITAR",
+  EDITAR_QUARTEIRAO_REQUEST                   : "EDITAR_QUARTEIRAO_REQUEST",
+  SET_UPDATED                                 : "SET_UPDATED",
+  SET_CREATED                                 : "SET_CREATED",
+  EXCLUIR_LADO_REDUCE                         : "EXCLUIR_LADO_REDUCE",
+  EXCLUIR_LADO_REQUEST                        : "EXCLUIR_LADO_REQUEST",
+  GET_QUARTEIRAO_POR_ID                       : "GET_QUARTEIRAO_POR_ID",
+  SET_QUARTEIRAO                              : "SET_QUARTEIRAO",
+  EXCLUIR_IMOVEL_REQUEST                      : "EXCLUIR_IMOVEL_REQUEST",
+  EXCLUIR_IMOVEL_REDUCE                       : "EXCLUIR_IMOVEL_REDUCE",
+  GET_QUARTEIROES_POR_MUNICIPIO_REQUEST       : "GET_QUARTEIROES_POR_MUNICIPIO_REQUEST",
+  ADD_QUARTEIRAO_REQUEST                      : "ADD_QUARTEIRAO_REQUEST",
+  ADD_QUARTEIRAO_SUCCESS                      : "ADD_QUARTEIRAO_SUCCESS",
+  INSERIR_QUARTEIRAO_ZONA_REQUEST             : "INSERIR_QUARTEIRAO_ZONA_REQUEST",
+  INSERIR_QUARTEIRAO_ZONA_SUCCESS             : "INSERIR_QUARTEIRAO_ZONA_SUCCESS",
+  INSERIR_QUARTEIRAO_ZONA_FAIL                : "INSERIR_QUARTEIRAO_ZONA_FAIL",
+  INSERIR_QUARTEIRAO_ZONA_RESET               : "INSERIR_QUARTEIRAO_ZONA_RESET",
+  REMOVER_QUARTEIRAO_ZONA_REQUEST             : "REMOVER_QUARTEIRAO_ZONA_REQUEST",
+  REMOVER_QUARTEIRAO_ZONA_SUCCESS             : "REMOVER_QUARTEIRAO_ZONA_SUCCESS",
+  REMOVER_QUARTEIRAO_ZONA_FAIL                : "REMOVER_QUARTEIRAO_ZONA_FAIL",
+  REMOVER_QUARTEIRAO_ZONA_RESET               : "REMOVER_QUARTEIRAO_ZONA_RESET"
 }
 
 /**
@@ -86,6 +95,21 @@ export const getQuarteiroesMunicipioRequest = ( municipio_id, ativo = undefined 
     payload: {
       municipio_id,
       ativo
+    }
+  }
+}
+
+/**
+ * Aciona o sagas para consultar os quarteiroes de um município na API
+ *
+ * @param integer municipio_id
+ * @returns
+ */
+export const getQuarteiroesMunicipioSemZonaRequest = ( municipio_id ) => {
+  return {
+    type: ActionTypes.GET_QUARTEIROES_MUNICIPIO_SEM_ZONA_REQUEST,
+    payload: {
+      municipio_id
     }
   }
 }
@@ -272,5 +296,70 @@ export const excluirImovelReduce = ( imovel_id, lado_id ) => {
       imovel_id,
       lado_id
     }
+  }
+}
+
+export const inserirQuarteiraoEmZonaRequest = ( id, zona_id, updatedZone=false ) => {
+  return {
+    type: ActionTypes.INSERIR_QUARTEIRAO_ZONA_REQUEST,
+    payload: {
+      id,
+      zona_id,
+      updatedZone
+    }
+  }
+}
+
+export const inserirQuarteiraoEmZonaSuccess = (updatedZone) => {
+  return {
+    type: ActionTypes.INSERIR_QUARTEIRAO_ZONA_SUCCESS,
+    payload: {
+      updatedZone
+    }
+  }
+}
+
+export const inserirQuarteiraoEmZonaFail = (updatedZone) => {
+  return {
+    type: ActionTypes.INSERIR_QUARTEIRAO_ZONA_FAIL,
+    payload: {
+      updatedZone
+    }
+  }
+}
+
+export const inserirQuarteiraoEmZonaReset = (updatedZone) => {
+  return {
+    type: ActionTypes.INSERIR_QUARTEIRAO_ZONA_RESET,
+    payload: {
+      updatedZone
+    }
+  }
+}
+
+export const removerQuarteiraoEmZonaRequest = ( id ) => {
+  return {
+    type: ActionTypes.REMOVER_QUARTEIRAO_ZONA_REQUEST,
+    payload: {
+      id,
+    }
+  }
+}
+
+export const removerQuarteiraoEmZonaSuccess = () => {
+  return {
+    type: ActionTypes.REMOVER_QUARTEIRAO_ZONA_SUCCESS,
+  }
+}
+
+export const removerQuarteiraoEmZonaFail = () => {
+  return {
+    type: ActionTypes.REMOVER_QUARTEIRAO_ZONA_FAIL,
+  }
+}
+
+export const removerQuarteiraoEmZonaReset = () => {
+  return {
+    type: ActionTypes.REMOVER_QUARTEIRAO_ZONA_RESET
   }
 }

--- a/src/store/Quarteirao/quarteiraoReduce.js
+++ b/src/store/Quarteirao/quarteiraoReduce.js
@@ -8,7 +8,10 @@ const INITIAL_STATE = {
   reload      : false,
   imovel      : new Imovel(),
   updated     : false,
-  created     : false
+  created     : false,
+  insertedZone: null,
+  removedZone:  null,
+  updatedZone:  null
 }
 
 export default function Quarteirao( state = INITIAL_STATE, action ) {
@@ -115,6 +118,51 @@ export default function Quarteirao( state = INITIAL_STATE, action ) {
         ...state,
         quarteirao,
         updated: !state.updated
+      }
+    }
+    case ActionTypes.INSERIR_QUARTEIRAO_ZONA_SUCCESS: {
+
+      const updatedZone = action.payload.updatedZone;
+      if(updatedZone)
+        return {...state,updatedZone:true}
+      else
+        return {...state,insertedZone:true}
+    }
+
+    case ActionTypes.INSERIR_QUARTEIRAO_ZONA_FAIL: {
+      const updatedZone = action.payload.updatedZone;
+      if(updatedZone)
+        return {...state,updatedZone:false}
+      else
+        return {...state,insertedZone:false}
+    }
+
+    case ActionTypes.INSERIR_QUARTEIRAO_ZONA_RESET: {
+      const updatedZone = action.payload.updatedZone;
+      if(updatedZone)
+        return {...state,updatedZone:null}
+      else
+        return {...state,insertedZone:null}
+    }
+
+    case ActionTypes.REMOVER_QUARTEIRAO_ZONA_SUCCESS: {
+      return {
+        ...state,
+        removedZone:true
+      }
+    }
+
+    case ActionTypes.REMOVER_QUARTEIRAO_ZONA_FAIL: {
+      return {
+        ...state,
+        removedZone:false
+      }
+    }
+
+    case ActionTypes.REMOVER_QUARTEIRAO_ZONA_RESET: {
+      return {
+        ...state,
+        removedZone:null
       }
     }
 

--- a/src/store/Quarteirao/quarteiraoSagas.js
+++ b/src/store/Quarteirao/quarteiraoSagas.js
@@ -30,6 +30,32 @@ export function* getQuarteiroes( action ) {
   }
 }
 
+/**
+ * Solicita ao service os quarteirões de um município que não estão em nenhuma zona
+ * @param {Object} action 
+ */
+export function* getQuarteiroesSemZona( action ) {
+  try {
+    const { data, status } = yield call( service.getQuarteiroesPorMunicipioSemZonaRequest, action.payload );
+
+    if( status === 200 ) {
+      yield put( QuarteiraoActions.setQuarteiroes( data ) );
+    }else {
+      yield put( AppConfigActions.showNotifyToast( "Falha ao consultar quarteirões: " + status, "error" ) );
+    }
+
+  } catch (err) {
+    if(err.response){
+      //Provavel erro de logica na API
+      yield put( AppConfigActions.showNotifyToast( "Erro ao consultar quarteirões, entre em contato com o suporte", "error" ) );
+      
+    }
+    //Se chegou aqui, significa que não houve resposta da API
+    else
+      yield put( AppConfigActions.showNotifyToast( "Erro ao consultar quarteirões, favor verifique a conexão", "error" ) );
+  }
+}
+
 export function* getLadosQuarteirao( action ) {
   try {
     const { data, status } = yield call( service.getLadosQuarteiraoRequest, action.payload );
@@ -196,9 +222,62 @@ export function* excluirImovel( action ) {
   }
 }
 
+export function* inserirQuarteiraoEmZona( action ) {
+  const { updatedZone } =  action.payload
+  try {
+    const { status } = yield call( service.inserirQuarteiraoEmZona, action.payload );
+
+    if( status === 200 ) {
+      yield put( QuarteiraoActions.inserirQuarteiraoEmZonaSuccess(updatedZone) );
+    }else {
+      yield put( QuarteiraoActions.inserirQuarteiraoEmZonaFail() );
+      yield put( AppConfigActions.showNotifyToast( "Falha ao adicionar quarteirao na zona: " + status, "error" ) );
+    }
+  } catch (err) {
+    yield put( QuarteiraoActions.inserirQuarteiraoEmZonaFail(updatedZone) );
+    if(err.response){
+      //Provavel erro de logica na API
+      yield put( AppConfigActions.showNotifyToast( "Erro ao adicionar quarteirao na zona, entre em contato com o suporte", "error" ) );
+      
+    }
+    //Se chegou aqui, significa que não houve resposta da API
+    else
+      yield put( AppConfigActions.showNotifyToast( "Erro ao adicionar quarteirao na zona, favor verifique a conexão", "error" ) );
+  }
+}
+
+export function* removerQuarteiraoEmZona( action ) {
+  try {
+    const { status } = yield call( service.removerQuarteiraoEmZona, action.payload );
+
+    if( status === 200 ) {
+      yield put( QuarteiraoActions.removerQuarteiraoEmZonaSuccess() );
+    }else {
+      yield put( QuarteiraoActions.removerQuarteiraoEmZonaFail() );
+      yield put( AppConfigActions.showNotifyToast( "Falha ao remover quarteirao da zona: " + status, "error" ) );
+    }
+  } catch (err) {
+    yield put( QuarteiraoActions.removerQuarteiraoEmZonaFail() );
+    if(err.response){
+      //Provavel erro de logica na API
+      yield put( AppConfigActions.showNotifyToast( "Erro ao remover quarteirao da zona, entre em contato com o suporte", "error" ) );
+      
+    }
+    //Se chegou aqui, significa que não houve resposta da API
+    else
+      yield put( AppConfigActions.showNotifyToast( "Erro ao remover quarteirao da zona, favor verifique a conexão", "error" ) );
+  }
+}
+
+
+
 // Watcher Sagas
 function* watchGetQuarteiroes() {
   yield takeLatest( QuarteiraoActions.ActionTypes.GET_QUARTEIROES_MUNICIPIO_REQUEST, getQuarteiroes );
+}
+
+function* watchGetQuarteiroesSemZona() {
+  yield takeLatest( QuarteiraoActions.ActionTypes.GET_QUARTEIROES_MUNICIPIO_SEM_ZONA_REQUEST, getQuarteiroesSemZona );
 }
 
 function* watchGetLadosQuarteirao() {
@@ -225,14 +304,24 @@ function* watchAddQuarteirao() {
   yield takeLatest( QuarteiraoActions.ActionTypes.ADD_QUARTEIRAO_REQUEST, addQuarteirao );
 }
 
+function* watchInserirQuarteiraoEmZona() {
+  yield takeLatest( QuarteiraoActions.ActionTypes.INSERIR_QUARTEIRAO_ZONA_REQUEST, inserirQuarteiraoEmZona );
+}
+function* watchRemoverQuarteiraoEmZona() {
+  yield takeLatest( QuarteiraoActions.ActionTypes.REMOVER_QUARTEIRAO_ZONA_REQUEST, removerQuarteiraoEmZona );
+}
+
 export function* quarteiraoSaga() {
   yield all( [
     watchGetQuarteiroes(),
+    watchGetQuarteiroesSemZona(),
     watchGetLadosQuarteirao(),
     watchSetQuarteirao(),
     watchGetQuarteiraoPorId(),
     watchExcluirLado(),
     watchExcluirImovel(),
     watchAddQuarteirao(),
+    watchInserirQuarteiraoEmZona(),
+    watchRemoverQuarteiraoEmZona(),
   ] );
 }

--- a/src/store/Zona/zonaActions.js
+++ b/src/store/Zona/zonaActions.js
@@ -15,11 +15,15 @@ export const ActionTypes = {
   CLEAR_UPDATE_ZONE: "CLEAR_UPDATE_ZONE"
 }
 
-export const getZoneByCityRequest = municipio_id => {
+/**
+ * ativo pode receber 'sim', 'nao' ou null, indicando para busca zonas ativas, inativas e ambas respectivamente
+**/
+export const getZoneByCityRequest = (municipio_id, ativo) => {
   return {
     type: ActionTypes.GET_ZONE_BY_CITY_REQUEST,
     payload: {
-      municipio_id
+      municipio_id,
+      ativo
     }
   }
 }
@@ -42,11 +46,11 @@ export const getZoneByIdRequest = id => {
   }
 }
 
-export const getZoneById = zona => {
+export const getZoneById = (data) => {
   return {
     type: ActionTypes.GET_ZONE_BY_ID_SUCCESS,
     payload: {
-      zona
+      data
     }
   }
 }
@@ -69,12 +73,13 @@ export const getZoneByLocality = zonas => {
   }
 }
 
-export const createZoneRequest = ( municipio_id, nome ) => {
+export const createZoneRequest = ( municipio_id, nome, quarteiroes_id ) => {
   return {
     type: ActionTypes.CREATE_ZONE_REQUEST,
     payload: {
       municipio_id,
-      nome
+      nome,
+      quarteiroes_id
     }
   }
 }

--- a/src/store/Zona/zonaReduce.js
+++ b/src/store/Zona/zonaReduce.js
@@ -3,6 +3,7 @@ import { ActionTypes } from './zonaActions';
 const INITIAL_STATE = {
   zona: {},
   zonas: [],
+  quarteiroes_zona: [],
   index: -1,
   created: null,
   updated: null,
@@ -21,7 +22,8 @@ export default function Zona(state = INITIAL_STATE, action) {
     case ActionTypes.GET_ZONE_BY_ID_SUCCESS: {
       return {
         ...state,
-        zona: action.payload.zona
+        zona: action.payload.data.zona,
+        quarteiroes_zona: action.payload.data.quarteiroes_zona
       }
     }
 

--- a/src/store/Zona/zonaSagas.js
+++ b/src/store/Zona/zonaSagas.js
@@ -5,7 +5,7 @@ import * as AppConfigActions from '../AppConfig/appConfigActions';
 
 export function* getZoneByCity(action) {
   try {
-    const { data, status } = yield call( servico.getZoneByCityRequest, action.payload.municipio_id );
+    const { data, status } = yield call( servico.getZoneByCityRequest, action.payload );
 
     if( status === 200 ) {
       yield put( ZonaActions.getZoneByCity( data ) );


### PR DESCRIPTION
Agora a plataforma permite add/edit/delete as zonas, quando antes só existia o add

Houve também ajustes na pagina de edição do quarteirão e no modal responsável por cadastra um novo quarteirão. Em ambos não havia forma de colocar um quarteirão sem nenhuma zona caso uma opção de zona já estivesse selecionada. Outro problema era que estava disponível zonas inativas para serem selecionadas